### PR TITLE
Refactor unit speed calculation

### DIFF
--- a/MiniRTS_Ultra_FULL_NoSprites_v12_1755074840.html
+++ b/MiniRTS_Ultra_FULL_NoSprites_v12_1755074840.html
@@ -84,6 +84,8 @@
 const clamp=(v,a,b)=>Math.max(a,Math.min(b,v));
 const rand=(a,b)=>a+Math.random()*(b-a);
 const dist2=(x1,y1,x2,y2)=>{const dx=x2-x1,dy=y2-y1;return dx*dx+dy*dy;};
+const SPEED_BUFF_MULT=1.5;
+const SLOW_MULT=0.6;
 
 /* ==== Canvas & camera ==== */
 const cvs=document.getElementById('game'), ctx=cvs.getContext('2d'); ctx.imageSmoothingEnabled=false;
@@ -141,15 +143,16 @@ class Entity{ constructor(x,y,owner=-1){ this.id=nextId++; this.x=x; this.y=y; t
 class Unit extends Entity{ constructor(x,y,owner,type='worker'){ super(x,y,owner); this.type=type; this.radius=12; this.speed=190; this.baseSpeed=190; this.destX=x; this.destY=y; this.attackRange=28; this.attackCd=0; this.dps=22; this.vision=480; this.isHero=false; this.mp=0; this.maxMp=0; this.cd1=0; this.cd2=0; this.cd3=0; this.cdM1=8; this.cdM2=12; this.cdM3=20; this.heroClass=null; this.levelStacks=0; this.inventory=[]; this.targetId=null; this.role=null; this.state='idle'; this.workTimer=0; this.carry=0; this.speedBuff=0; this.slow=0; this.summonTimer=0; this.retreat=false; this.regen=0.25; }
   setDest(x,y){ this.destX=x; this.destY=y; this.state='move'; this.targetId=null; }
   setTarget(e){ this.targetId=e?e.id:null; this.state=e?'fight':'move'; }
+  currentSpeed(){ return this.speed*(this.speedBuff?SPEED_BUFF_MULT:1)*(this.slow?SLOW_MULT:1); }
   thinkWorker(dt){
     if(this.role!=='rice' && this.role!=='water') return;
     const P=players[this.owner]; const HQ=P.structures.find(s=>s.kind==='hq');
     const node=(this.role==='rice'?nearestNode('rice',P):nearestNode('water',P));
     if(!HQ || !node) return;
     if(this.state==='idle'){ this.state='to_node'; this.destX=node.x+rand(-24,24); this.destY=node.y+rand(-24,24); }
-    if(this.state==='to_node'){ const dx=this.destX-this.x, dy=this.destY-this.y, d=Math.hypot(dx,dy); if(d>2){ const v=this.speed*(this.speedBuff?1.5:1.0)*(this.slow?0.6:1.0); const nx=this.x+dx/d*v*dt, ny=this.y+dy/d*v*dt; if(!isBlocked(nx,ny)){ this.x=nx; this.y=ny; } } else { this.state='harvest'; this.workTimer = (this.role==='rice'?2.2:2.6); } }
+    if(this.state==='to_node'){ const dx=this.destX-this.x, dy=this.destY-this.y, d=Math.hypot(dx,dy); if(d>2){ const v=this.currentSpeed(); const nx=this.x+dx/d*v*dt, ny=this.y+dy/d*v*dt; if(!isBlocked(nx,ny)){ this.x=nx; this.y=ny; } } else { this.state='harvest'; this.workTimer = (this.role==='rice'?2.2:2.6); } }
     if(this.state==='harvest'){ this.workTimer-=dt; if(this.workTimer<=0){ this.carry = (this.role==='rice'?12:9); this.state='to_hq'; this.destX=HQ.x+rand(-32,32); this.destY=HQ.y+rand(-32,32); } }
-    if(this.state==='to_hq'){ const dx=this.destX-this.x, dy=this.destY-this.y, d=Math.hypot(dx,dy); if(d>2){ const v=this.speed*(this.speedBuff?1.5:1.0)*(this.slow?0.6:1.0); const nx=this.x+dx/d*v*dt, ny=this.y+dy/d*v*dt; if(!isBlocked(nx,ny)){ this.x=nx; this.y=ny; } } else { if(this.carry>0){ if(this.role==='rice') P.res.rice+=this.carry; else P.res.water+=this.carry; if(this.owner===0) updateRes(); this.carry=0; } this.state='to_node'; this.destX=node.x+rand(-24,24); this.destY=node.y+rand(-24,24); } }
+    if(this.state==='to_hq'){ const dx=this.destX-this.x, dy=this.destY-this.y, d=Math.hypot(dx,dy); if(d>2){ const v=this.currentSpeed(); const nx=this.x+dx/d*v*dt, ny=this.y+dy/d*v*dt; if(!isBlocked(nx,ny)){ this.x=nx; this.y=ny; } } else { if(this.carry>0){ if(this.role==='rice') P.res.rice+=this.carry; else P.res.water+=this.carry; if(this.owner===0) updateRes(); this.carry=0; } this.state='to_node'; this.destX=node.x+rand(-24,24); this.destY=node.y+rand(-24,24); } }
   }
   update(dt){
     if(this.dead) return;
@@ -168,11 +171,11 @@ class Unit extends Entity{ constructor(x,y,owner,type='worker'){ super(x,y,owner
     const target=getById(this.targetId);
     if(target && !target.dead && !this.retreat){
       const dx=target.x-this.x, dy=target.y-this.y; const d=Math.hypot(dx,dy);
-      if(d>this.attackRange){ const v=this.speed*(this.speedBuff?1.5:1.0)*(this.slow?0.6:1.0); const nx=this.x+dx/d*v*dt, ny=this.y+dy/d*v*dt; if(!isBlocked(nx,ny)){ this.x=nx; this.y=ny; } }
+      if(d>this.attackRange){ const v=this.currentSpeed(); const nx=this.x+dx/d*v*dt, ny=this.y+dy/d*v*dt; if(!isBlocked(nx,ny)){ this.x=nx; this.y=ny; } }
       else { this.attackCd-=dt; if(this.attackCd<=0){ this.attackCd=.55; target.damage(this.dps,this.owner); if(!muted) beep(220+this.dps,0.05,'square',0.03); } }
     } else {
       const dx=this.destX-this.x, dy=this.destY-this.y; const d=Math.hypot(dx,dy);
-      if(d>2){ const v=this.speed*(this.speedBuff?1.5:1.0)*(this.slow?0.6:1.0); const nx=this.x+dx/d*v*dt, ny=this.y+dy/d*v*dt; if(!isBlocked(nx,ny)){ this.x=nx; this.y=ny; } }
+      if(d>2){ const v=this.currentSpeed(); const nx=this.x+dx/d*v*dt, ny=this.y+dy/d*v*dt; if(!isBlocked(nx,ny)){ this.x=nx; this.y=ny; } }
     }
     // auto-acquire target (агр рядом)
     if(!this.isHero){ const enemies=enemiesFor(this.owner); let best=null,bd=1e9; for(const e of enemies){ if(e.dead) continue; const d=dist2(this.x,this.y,e.x,e.y); if(d<bd && d<=this.vision*this.vision){ bd=d; best=e; } } if(best){ this.setTarget(best); } }


### PR DESCRIPTION
## Summary
- add currentSpeed helper method to Unit
- replace duplicate speed formulas with method calls
- define constants for speed buff and slow multipliers

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c5664ee3c8327be0b70651550ad36