### PR TITLE
feat: add spatial index for entity queries

### DIFF
--- a/MiniRTS_Ultra_FULL_NoSprites_v12_1755074840.html
+++ b/MiniRTS_Ultra_FULL_NoSprites_v12_1755074840.html
@@ -77,8 +77,8 @@
   </div>
 </div>
 
-<script>
-(function(){'use strict';
+<script type="module">
+import {SpatialIndex} from './spatialIndex.js';
 
 /* ==== Helpers ==== */
 const clamp=(v,a,b)=>Math.max(a,Math.min(b,v));
@@ -90,6 +90,7 @@ const cvs=document.getElementById('game'), ctx=cvs.getContext('2d'); ctx.imageSm
 const mini=document.getElementById('minimap'), mctx=mini.getContext('2d'); mctx.imageSmoothingEnabled=false;
 const DPR=Math.max(1,window.devicePixelRatio||1);
 const world={width:12000,height:8000,camX:0,camY:0,zoom:1};
+const spatial=new SpatialIndex(256);
 function resize(){const w=cvs.clientWidth,h=cvs.clientHeight;cvs.width=Math.floor(w*DPR);cvs.height=Math.floor(h*DPR);ctx.setTransform(DPR,0,0,DPR,0,0);}
 new ResizeObserver(resize).observe(cvs); resize();
 function screenToWorld(sx,sy){return {x:sx/world.zoom+world.camX,y:sy/world.zoom+world.camY};}
@@ -175,7 +176,16 @@ class Unit extends Entity{ constructor(x,y,owner,type='worker'){ super(x,y,owner
       if(d>2){ const v=this.speed*(this.speedBuff?1.5:1.0)*(this.slow?0.6:1.0); const nx=this.x+dx/d*v*dt, ny=this.y+dy/d*v*dt; if(!isBlocked(nx,ny)){ this.x=nx; this.y=ny; } }
     }
     // auto-acquire target (агр рядом)
-    if(!this.isHero){ const enemies=enemiesFor(this.owner); let best=null,bd=1e9; for(const e of enemies){ if(e.dead) continue; const d=dist2(this.x,this.y,e.x,e.y); if(d<bd && d<=this.vision*this.vision){ bd=d; best=e; } } if(best){ this.setTarget(best); } }
+    if(!this.isHero){
+      const enemies=enemiesFor(this.owner,this.x,this.y,this.vision);
+      let best=null,bd=1e9;
+      for(const e of enemies){
+        const d=dist2(this.x,this.y,e.x,e.y);
+        if(d<bd && d<=this.vision*this.vision){ bd=d; best=e; }
+      }
+      if(best){ this.setTarget(best); }
+    }
+    spatial.update(this);
   }
   draw(){
     if(this.owner!==0 && !isVisible(this.x,this.y)) return;
@@ -204,6 +214,7 @@ class NeutralCreep extends Entity{ constructor(x,y,tier=1){ super(x,y,-1); this.
     if(!this.aggro && md<this.leash) this.aggro=true;
     if(this.aggro && tgt && md<this.leash*1.2){ if(md>this.attackRange){ const ux=(tgt.x-this.x)/md, uy=(tgt.y-this.y)/md; const nx=this.x+ux*80*dt, ny=this.y+uy*80*dt; if(!isBlocked(nx,ny)){ this.x=nx; this.y=ny; } } else { this.attackCd-=dt; if(this.attackCd<=0){ this.attackCd=.65; tgt.damage(this.dps,-1); } } }
     else { const dx=this.homeX-this.x, dy=this.homeY-this.y, d=Math.hypot(dx,dy); if(d>2){ const nx=this.x+dx/d*60*dt, ny=this.y+dy/d*60*dt; if(!isBlocked(nx,ny)){ this.x=nx; this.y=ny; } } this.aggro=false; }
+    spatial.update(this);
   }
   draw(){ if(!isExplored(this.x,this.y)) return; const s=worldToScreen(this.x,this.y); ctx.fillStyle=this.tier>=3?'#b86':(this.tier==2?'#a68':'#9fb2a1'); ctx.beginPath(); ctx.arc(s.x,s.y,12*world.zoom,0,6.283); ctx.fill(); drawHp(s.x,s.y-18*world.zoom,this.hp/this.maxHp); }
 }
@@ -222,11 +233,22 @@ function updateRes(){ resUI.rice.textContent=players[0].res.rice|0; resUI.water.
 
 /* ==== ID lookup ==== */
 function getById(id){ if(!id) return null; for(const p of players){ for(const u of p.units){ if(u.id===id) return u; } for(const s of p.structures){ if(s.id===id) return s; } } for(const n of neutral.units){ if(n.id===id) return n; } return null; }
-function enemiesFor(owner){ const arr=[]; for(const p of players){ if(p===players[owner]) continue; arr.push(...p.units.filter(u=>!u.dead), ...p.structures.filter(s=>!s.isGhost)); } arr.push(...neutral.units); return arr; }
+function enemiesFor(owner,x,y,r){
+  const res=[];
+  const candidates=spatial.queryCircle(x,y,r);
+  for(const e of candidates){
+    if(e.dead) continue;
+    if(e.owner===owner) continue;
+    if(e instanceof Structure && e.isGhost) continue;
+    if(e instanceof ItemDrop) continue;
+    res.push(e);
+  }
+  return res;
+}
 
 /* ==== Training & buildings ==== */
 const COSTS={ barracks:{rice:180,water:70}, mBarracks:{rice:220,water:110}, well:{rice:140,water:0}, range:{rice:160,water:80}, altar:{rice:200,water:140} };
-function placeGhost(owner,x,y,kind){ const cost=COSTS[kind]||{rice:0,water:0}; const R=players[owner].res; if(R.rice<cost.rice||R.water<cost.water) return false; if(isBlocked(x,y)) return false; R.rice-=cost.rice; if(owner===0) updateRes(); const g=new Structure(x,y,owner,kind,true); players[owner].structures.push(g); return true; }
+function placeGhost(owner,x,y,kind){ const cost=COSTS[kind]||{rice:0,water:0}; const R=players[owner].res; if(R.rice<cost.rice||R.water<cost.water) return false; if(isBlocked(x,y)) return false; R.rice-=cost.rice; if(owner===0) updateRes(); const g=new Structure(x,y,owner,kind,true); players[owner].structures.push(g); spatial.add(g); return true; }
 function trainUnit(owner,barr,unitType){
   if(players[owner].units.filter(u=>!u.dead && !u.isHero).length>=POP_CAP) return false;
   const cost=unitType==='soldier'?{rice:60,water:24}: unitType==='mage'?{rice:80,water:46}: unitType==='archer'?{rice:70,water:36}: unitType==='worker'?{rice:50,water:12}:{rice:0,water:0};
@@ -236,6 +258,7 @@ function trainUnit(owner,barr,unitType){
   if(unitType==='archer'){ u.dps=20; u.maxHp=120; u.hp=120; u.attackRange=250; u.vision=520; u.regen=0.25; }
   if(unitType==='mage'){ u.dps=22; u.maxHp=110; u.hp=110; u.attackRange=210; u.regen=0.25; }
   players[owner].units.push(u);
+  spatial.add(u);
   if(!muted) beep(520,0.06,'sawtooth',0.04);
   return true;
 }
@@ -252,7 +275,7 @@ function spawnHero(owner,x,y,cls=null){
   if(cls==='rogue'){ h.heroName='Разбойник'; h.cdM1=10; h.cdM2=9; h.cdM3=16; }
   if(cls==='archmage'){ h.heroName='Аркан‑маг'; h.cdM1=7; h.cdM2=18; h.cdM3=28; }
   h.onDeath=()=>{ if(owner===0){ abilityBar.style.display='none'; invPanel.style.display='none'; } players[owner].hero=null; };
-  players[owner].units.push(h); players[owner].hero=h; return h;
+  players[owner].units.push(h); players[owner].hero=h; spatial.add(h); return h;
 }
 function heroGainFromNeutral(owner,tier){
   const h=players[owner]?.hero; if(!h||h.dead) return;
@@ -286,11 +309,11 @@ function tryCast(slot){ const h=players[0].hero; if(!h||h.dead) return;
     h.cd1=h.cdM1; if(h.owner===0) setHeroUI(h); }
   if(slot===2 && h.cd2<=0){ if(h.heroClass==='paladin'){ if(h.mp<35) return; h.mp-=35; h.shield=(h.shield||0)+120; beep(280,0.08,'triangle',0.05); } 
     else if(h.heroClass==='rogue'){ if(h.mp<40) return; h.mp-=40; const R=180; for(const e of players[1].units.concat(players[2].units,neutral.units)){ if(e.dead) continue; if(Math.hypot(e.x-h.x,e.y-h.y)<=R){ e.damage(70,0); } } beep(720,0.08,'square',0.06); }
-    else { if(h.mp<60) return; h.mp-=60; const e=new Unit(h.x+24,h.y,h.owner,'elemental'); e.dps=18; e.maxHp=200; e.hp=200; e.attackRange=210; e.summonTimer=20; players[h.owner].units.push(e); beep(480,0.09,'sawtooth',0.06); }
+    else { if(h.mp<60) return; h.mp-=60; const e=new Unit(h.x+24,h.y,h.owner,'elemental'); e.dps=18; e.maxHp=200; e.hp=200; e.attackRange=210; e.summonTimer=20; players[h.owner].units.push(e); spatial.add(e); beep(480,0.09,'sawtooth',0.06); }
     h.cd2=h.cdM2; if(h.owner===0) setHeroUI(h); }
   if(slot===3 && h.cd3<=0){ if(h.heroClass==='paladin'){ if(h.mp<45) return; h.mp-=45; const R=200; for(const u of players[0].units){ if(Math.hypot(u.x-h.x,u.y-h.y)<=R) u.hp=Math.min(u.maxHp,u.hp+70); } for(const e of players[1].units.concat(players[2].units,neutral.units)){ if(Math.hypot(e.x-h.x,e.y-h.y)<=R) e.damage(60,0); } beep(560,0.09,'triangle',0.06); }
     else if(h.heroClass==='rogue'){ if(h.mp<55) return; h.mp-=55; const R=220; for(const e of players[1].units.concat(players[2].units,neutral.units)){ if(Math.hypot(e.x-h.x,e.y-h.y)<=R){ e.damage(50,0); e.slow=3.5; } } beep(900,0.07,'square',0.06); }
-    else { if(h.mp<90) return; h.mp-=90; const d=new Unit(h.x+28,h.y+12,h.owner,'demon'); d.dps=36; d.maxHp=500; d.hp=500; d.attackRange=60; d.summonTimer=25; players[h.owner].units.push(d); beep(360,0.12,'sawtooth',0.07); }
+    else { if(h.mp<90) return; h.mp-=90; const d=new Unit(h.x+28,h.y+12,h.owner,'demon'); d.dps=36; d.maxHp=500; d.hp=500; d.attackRange=60; d.summonTimer=25; players[h.owner].units.push(d); spatial.add(d); beep(360,0.12,'sawtooth',0.07); }
     h.cd3=h.cdM3; if(h.owner===0) setHeroUI(h); }
 }
 
@@ -303,9 +326,16 @@ window.addEventListener('keydown', e=>{ const k=e.key.toLowerCase(); input.keys[
 window.addEventListener('keyup', e=>{ input.keys[e.key.toLowerCase()]=false; });
 
 function entityAt(wx,wy){
-  function hit(arr,r){ let best=null,bD=1e9; for(const e of arr){ if(e.dead) continue; const d=dist2(wx,wy,e.x,e.y); const rr=r(e); if(d<=rr*rr && d<bD){ bD=d; best=e; } } return best; }
-  const a=[...players[0].units,...players[1].units,...players[2].units,...neutral.units]; const b=[...players[0].structures,...players[1].structures,...players[2].structures];
-  return hit(a,e=>e.radius+10) || hit(b,e=>e.radius+14) || null;
+  const candidates=spatial.queryCircle(wx,wy,60);
+  let best=null,bD=1e9;
+  for(const e of candidates){
+    if(e.dead) continue;
+    if(e instanceof Structure && e.isGhost) continue;
+    const rr=(e instanceof Structure? e.radius+14 : e.radius+10);
+    const d=dist2(wx,wy,e.x,e.y);
+    if(d<=rr*rr && d<bD){ bD=d; best=e; }
+  }
+  return best;
 }
 function unselectAll(){ for(const p of [players[0],players[1],players[2]]){ for(const u of p.units) u.selected=false; for(const s of p.structures) s.selected=false; } for(const n of neutral.units) n.selected=false; }
 function selectSameTypeOnScreen(type){ const x1=world.camX, y1=world.camY, x2=world.camX + cvs.width/DPR/world.zoom, y2=world.camY + cvs.height/DPR/world.zoom; for(const u of players[0].units){ if(u.dead) continue; if(u.type===type){ if(u.x>=x1&&u.x<=x2&&u.y>=y1&&u.y<=y2) u.selected=true; } } }
@@ -408,23 +438,36 @@ function aiThink(dt,id){
     if(tgt){ P.units.filter(u=>u.type!=='worker').forEach(u=>{ if(!u.retreat) u.setTarget(tgt); }); }
   }
 }
-function nearestNeutralCamp(P){ let best=null, bd=1e9; for(const n of neutral.units){ if(n.dead) continue; const d=dist2(P.structures[0].x,P.structures[0].y,n.x,n.y); if(d<bd){ bd=d; best=n; } } return best; }
+function nearestNeutralCamp(P){
+  let best=null, bd=1e9;
+  const hq=P.structures[0];
+  if(!hq) return null;
+  const range=Math.max(world.width,world.height);
+  const candidates=spatial.queryCircle(hq.x,hq.y,range);
+  for(const n of candidates){
+    if(!(n instanceof NeutralCreep) || n.dead) continue;
+    const d=dist2(hq.x,hq.y,n.x,n.y);
+    if(d<bd){ bd=d; best=n; }
+  }
+  return best;
+}
 
 /* ==== Setup/Reset ==== */
 function resetGame(){
+  spatial.clear();
   genBlockers();
   for(const p of players){ p.units.length=0; p.structures.length=0; p.hero=null; p.res.rice=220; p.res.water=100; p.aiPlan=null; }
   neutral.units.length=0; drops.length=0; riceNodes.length=0; waterNodes.length=0; explored.fill(0); visible.fill(0); updateRes();
   const pos=[{x:900,y:900},{x:world.width-1200,y:1200},{x:world.width-1800,y:world.height-1400}];
-  for(let i=0;i<3;i++){ const HQ=new Structure(pos[i].x,pos[i].y,i,'hq',false); players[i].structures.push(HQ);
-    for(let k=0;k<6;k++){ const w=new Unit(HQ.x+(k%3)*24, HQ.y+60+Math.floor(k/3)*24, i,'worker'); players[i].units.push(w); w.role=(k%2===0)?'rice':'water'; } // 3/3
+  for(let i=0;i<3;i++){ const HQ=new Structure(pos[i].x,pos[i].y,i,'hq',false); players[i].structures.push(HQ); spatial.add(HQ);
+    for(let k=0;k<6;k++){ const w=new Unit(HQ.x+(k%3)*24, HQ.y+60+Math.floor(k/3)*24, i,'worker'); players[i].units.push(w); w.role=(k%2===0)?'rice':'water'; spatial.add(w); } // 3/3
     const cls = (i===0? null : (Math.random()<0.34?'paladin':(Math.random()<0.67?'rogue':'archmage')));
     spawnHero(i, HQ.x+80, HQ.y-20, cls);
     riceNodes.push(new ResourceNode(HQ.x+220,HQ.y+160,'rice')); waterNodes.push(new ResourceNode(HQ.x-220,HQ.y+160,'water'));
   }
   // neutrals far from starts
   function farFromAll(x,y,dist){ for(const p of players){ const s=p.structures[0]; if(Math.hypot(x-s.x,y-s.y)<dist) return false; } return true; }
-  let placed=0; while(placed<28){ const x=200+Math.random()*(world.width-400), y=200+Math.random()*(world.height-400); if(!farFromAll(x,y,1200)) continue; const tier = Math.random()<0.6?1:(Math.random()<0.7?2:3); neutral.units.push(new NeutralCreep(x,y,tier)); placed++; }
+  let placed=0; while(placed<28){ const x=200+Math.random()*(world.width-400), y=200+Math.random()*(world.height-400); if(!farFromAll(x,y,1200)) continue; const tier = Math.random()<0.6?1:(Math.random()<0.7?2:3); const c=new NeutralCreep(x,y,tier); neutral.units.push(c); spatial.add(c); placed++; }
   // reveal around player
   revealCircle(players[0].structures[0].x, players[0].structures[0].y, 900);
   world.camX=players[0].structures[0].x-400; world.camY=players[0].structures[0].y-300;
@@ -444,10 +487,13 @@ function loop(t){ const dt=Math.min(0.033,(t-last)/1000); last=t; simTime+=dt;
     for(const p of players){ for(const s of p.structures) s.update(dt); for(const u of p.units) u.update(dt); if(p.ai) aiThink(dt, players.indexOf(p)); }
     for(const n of neutral.units){ n.update(dt); if(n.dead && !n.awarded){ if(n.lastHitBy!=null && n.lastHitBy>=0){ heroGainFromNeutral(n.lastHitBy, n.tier); if(Math.random()<0.5){ drops.push(new ItemDrop(n.x+rand(-10,10), n.y+rand(-10,10), lootFromTier(n.tier))); } } n.awarded=true; } }
     // cleanup neutrals (remove processed corpses)
-    for(let i=neutral.units.length-1;i>=0;i--){ if(neutral.units[i].dead && neutral.units[i].awarded){ neutral.units.splice(i,1); } }
+    for(let i=neutral.units.length-1;i>=0;i--){ const n=neutral.units[i]; if(n.dead && n.awarded){ neutral.units.splice(i,1); spatial.remove(n); } }
     tryPickup();
     // cleanup players lists
-    for(const p of [players[0],players[1],players[2]]){ p.units=p.units.filter(u=>!u.dead); p.structures=p.structures.filter(s=>!s.dead); }
+    for(const p of [players[0],players[1],players[2]]){
+      for(let i=p.units.length-1;i>=0;i--){ if(p.units[i].dead){ spatial.remove(p.units[i]); p.units.splice(i,1); } }
+      for(let i=p.structures.length-1;i>=0;i--){ if(p.structures[i].dead){ spatial.remove(p.structures[i]); p.structures.splice(i,1); } }
+    }
   }
   ctx.clearRect(0,0,cvs.width,cvs.height);
   drawTerrain();
@@ -477,6 +523,6 @@ window.addEventListener('keydown', e=>{
 });
 
 function startBuild(kind){ input.buildMode=kind; document.getElementById('buildTip').style.display='block'; }
-})();</script>
+</script>
 </body>
 </html>

--- a/spatialIndex.js
+++ b/spatialIndex.js
@@ -1,0 +1,73 @@
+export class SpatialIndex {
+  constructor(cellSize = 256) {
+    this.cellSize = cellSize;
+    this.cells = new Map();
+  }
+
+  _key(cx, cy) {
+    return `${cx},${cy}`;
+  }
+
+  _cellKey(x, y) {
+    return this._key(
+      Math.floor(x / this.cellSize),
+      Math.floor(y / this.cellSize)
+    );
+  }
+
+  add(e) {
+    const key = this._cellKey(e.x, e.y);
+    let cell = this.cells.get(key);
+    if (!cell) {
+      cell = new Set();
+      this.cells.set(key, cell);
+    }
+    cell.add(e);
+    e._siKey = key;
+  }
+
+  remove(e) {
+    const key = e._siKey;
+    if (!key) return;
+    const cell = this.cells.get(key);
+    if (cell) {
+      cell.delete(e);
+      if (cell.size === 0) this.cells.delete(key);
+    }
+    e._siKey = null;
+  }
+
+  update(e) {
+    const key = this._cellKey(e.x, e.y);
+    if (key === e._siKey) return;
+    this.remove(e);
+    let cell = this.cells.get(key);
+    if (!cell) {
+      cell = new Set();
+      this.cells.set(key, cell);
+    }
+    cell.add(e);
+    e._siKey = key;
+  }
+
+  queryCircle(x, y, r) {
+    const res = [];
+    const cs = this.cellSize;
+    const minX = Math.floor((x - r) / cs);
+    const maxX = Math.floor((x + r) / cs);
+    const minY = Math.floor((y - r) / cs);
+    const maxY = Math.floor((y + r) / cs);
+    for (let cy = minY; cy <= maxY; cy++) {
+      for (let cx = minX; cx <= maxX; cx++) {
+        const cell = this.cells.get(this._key(cx, cy));
+        if (cell) res.push(...cell);
+      }
+    }
+    return res;
+  }
+
+  clear() {
+    this.cells.clear();
+  }
+}
+


### PR DESCRIPTION
## Summary
- introduce grid-based SpatialIndex module
- replace linear searches with spatial index queries for entities
- maintain index on entity creation and removal

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c5667b76883278b0b0a15eeaeedfa