### PR TITLE
refactor: remove globalThis usage and use modules

### DIFF
--- a/src/ai.js
+++ b/src/ai.js
@@ -1,16 +1,14 @@
 /* ==== AI ==== */
-function aiInitPlan(P) {
+import { players, COSTS, POP_CAP, placeGhost, neutral, dist2 } from './main.js';
+import { isBlocked } from './terrain.js';
+
+export function aiInitPlan(P) {
   const cls = P.hero.heroClass;
   if (cls === 'paladin') { P.aiPlan = { comp: { soldier: 0.6, archer: 0.4, mage: 0.0 }, open: ['well', 'barracks', 'range'], state: 'farm', pushAt: 10, nextBuild: 0 }; }
   else if (cls === 'rogue') { P.aiPlan = { comp: { soldier: 0.4, archer: 0.6, mage: 0.0 }, open: ['well', 'range', 'barracks'], state: 'farm', pushAt: 8, nextBuild: 0 }; }
   else { P.aiPlan = { comp: { soldier: 0.2, archer: 0.4, mage: 0.4 }, open: ['well', 'mBarracks', 'range'], state: 'farm', pushAt: 12, nextBuild: 0 }; }
 }
-function aiThink(dt, id) {
-  const players = globalThis.players;
-  const COSTS = globalThis.COSTS;
-  const POP_CAP = globalThis.POP_CAP;
-  const placeGhost = globalThis.placeGhost;
-  const isBlocked = globalThis.isBlocked;
+export function aiThink(dt, id) {
   if (!players[id].ai) return;
   if (!players[id].aiPlan) aiInitPlan(players[id]);
   const P = players[id];
@@ -39,7 +37,6 @@ function aiThink(dt, id) {
     else if (mb) mb.queue.push('mage');
   }
   // hero farms nearest neutral
-  const neutral = globalThis.neutral;
   const hero = P.hero; if (hero && !hero.dead) { const tgt = nearestNeutralCamp(P); if (tgt) { hero.setTarget(tgt); } }
   // army rally / attack
   if (P.units.filter(u => u.type !== 'worker' && !u.isHero).length >= P.aiPlan.pushAt) {
@@ -48,9 +45,6 @@ function aiThink(dt, id) {
     if (tgt) { P.units.filter(u => u.type !== 'worker').forEach(u => { if (!u.retreat) u.setTarget(tgt); }); }
   }
 }
-function nearestNeutralCamp(P) {
-  const neutral = globalThis.neutral;
-  const { dist2 } = globalThis;
+export function nearestNeutralCamp(P) {
   let best = null, bd = 1e9; for (const n of neutral.units) { if (n.dead) continue; const d = dist2(P.structures[0].x, P.structures[0].y, n.x, n.y); if (d < bd) { bd = d; best = n; } } return best;
 }
-Object.assign(globalThis, { aiInitPlan, aiThink, nearestNeutralCamp });

--- a/src/fog.js
+++ b/src/fog.js
@@ -1,15 +1,15 @@
 /* ==== Fog of war ==== */
-const F_W = 180, F_H = 120;
-const explored = new Uint8Array(F_W * F_H), visible = new Uint8Array(F_W * F_H);
-function fogIndex(wx, wy) {
-  const { clamp, world } = globalThis;
+import { clamp, world, fogEnabled, cvs, ctx, DPR } from './main.js';
+
+export const F_W = 180, F_H = 120;
+export const explored = new Uint8Array(F_W * F_H), visible = new Uint8Array(F_W * F_H);
+export function fogIndex(wx, wy) {
   const x = clamp(Math.floor(wx / world.width * F_W), 0, F_W - 1);
   const y = clamp(Math.floor(wy / world.height * F_H), 0, F_H - 1);
   return y * F_W + x;
 }
-function clearVisible() { visible.fill(0); }
-function revealCircle(wx, wy, r) {
-  const { clamp, world } = globalThis;
+export function clearVisible() { visible.fill(0); }
+export function revealCircle(wx, wy, r) {
   const cx = Math.floor(wx / world.width * F_W), cy = Math.floor(wy / world.height * F_H), rr = (r / world.width * F_W), R2 = rr * rr;
   const x0 = clamp(Math.floor(cx - rr - 1), 0, F_W - 1), x1 = clamp(Math.ceil(cx + rr + 1), 0, F_W - 1);
   const y0 = clamp(Math.floor(cy - rr - 1), 0, F_H - 1), y1 = clamp(Math.ceil(cy + rr + 1), 0, F_H - 1);
@@ -20,10 +20,9 @@ function revealCircle(wx, wy, r) {
     }
   }
 }
-function isVisible(wx, wy) { return !globalThis.fogEnabled || visible[fogIndex(wx, wy)] === 1; }
-function isExplored(wx, wy) { return !globalThis.fogEnabled || explored[fogIndex(wx, wy)] === 1; }
-function drawFog() {
-  const { fogEnabled, cvs, ctx, DPR, world } = globalThis;
+export function isVisible(wx, wy) { return !fogEnabled || visible[fogIndex(wx, wy)] === 1; }
+export function isExplored(wx, wy) { return !fogEnabled || explored[fogIndex(wx, wy)] === 1; }
+export function drawFog() {
   if (!fogEnabled) return;
   const w = cvs.width, h = cvs.height;
   const img = ctx.createImageData(w, h);
@@ -44,4 +43,3 @@ function drawFog() {
   }
   ctx.putImageData(img, 0, 0);
 }
-Object.assign(globalThis, { F_W, F_H, explored, visible, fogIndex, clearVisible, revealCircle, isVisible, isExplored, drawFog });

--- a/src/main.js
+++ b/src/main.js
@@ -1,11 +1,18 @@
+import { genBlockers, drawTerrain, isBlocked } from './terrain.js';
+import { clearVisible, revealCircle, isVisible, drawFog } from './fog.js';
+import { aiThink } from './ai.js';
+import './ui.js';
+
 /* ==== Helpers ==== */
 const clamp = (v, a, b) => Math.max(a, Math.min(b, v));
 const rand = (a, b) => a + Math.random() * (b - a);
 const dist2 = (x1, y1, x2, y2) => { const dx = x2 - x1, dy = y2 - y1; return dx * dx + dy * dy; };
 
 /* ==== Canvas & camera ==== */
-const cvs = document.getElementById('game'), ctx = cvs.getContext('2d'); ctx.imageSmoothingEnabled = false;
-const mini = document.getElementById('minimap'), mctx = mini.getContext('2d'); mctx.imageSmoothingEnabled = false;
+const cvs = document.getElementById('game');
+const ctx = cvs.getContext('2d'); ctx.imageSmoothingEnabled = false;
+const mini = document.getElementById('minimap');
+const mctx = mini.getContext('2d'); mctx.imageSmoothingEnabled = false;
 const DPR = Math.max(1, window.devicePixelRatio || 1);
 const world = { width: 12000, height: 8000, camX: 0, camY: 0, zoom: 1 };
 function resize() { const w = cvs.clientWidth, h = cvs.clientHeight; cvs.width = Math.floor(w * DPR); cvs.height = Math.floor(h * DPR); ctx.setTransform(DPR, 0, 0, DPR, 0, 0); }
@@ -13,17 +20,21 @@ new ResizeObserver(resize).observe(cvs); resize();
 function screenToWorld(sx, sy) { return { x: sx / world.zoom + world.camX, y: sy / world.zoom + world.camY }; }
 function worldToScreen(wx, wy) { return { x: (wx - world.camX) * world.zoom, y: (wy - world.camY) * world.zoom }; }
 
-Object.assign(globalThis, { clamp, rand, dist2, cvs, ctx, mini, mctx, DPR, world, screenToWorld, worldToScreen });
+let paused = true;
+let muted = false;
+let fogEnabled = true;
+function setPaused(v) { paused = v; }
+function setMuted(v) { muted = v; }
+function setFogEnabled(v) { fogEnabled = v; }
 
 /* ==== Audio (простые огибающие без внешних файлов) ==== */
 const AC = window.AudioContext ? new AudioContext() : null;
 function beep(freq = 440, dur = 0.08, type = 'triangle', gain = 0.06) {
-  if (globalThis.muted || !AC) return;
+  if (muted || !AC) return;
   const o = AC.createOscillator(), g = AC.createGain();
   o.type = type; o.frequency.value = freq; o.connect(g); g.connect(AC.destination); g.gain.value = gain;
   o.start(); g.gain.exponentialRampToValueAtTime(0.0001, AC.currentTime + dur); o.stop(AC.currentTime + dur);
 }
-globalThis.beep = beep;
 
       /* ==== Entities ==== */
       let nextId = 1, simTime = 0;
@@ -202,7 +213,7 @@ globalThis.beep = beep;
       const input = { x: 0, y: 0, wx: 0, wy: 0, keys: {}, buildMode: null, lastClickT: 0, lastClickType: null };
       cvs.addEventListener('mousemove', e => { input.x = e.offsetX; input.y = e.offsetY; const w = screenToWorld(input.x, input.y); input.wx = w.x; input.wy = w.y; });
       cvs.addEventListener('contextmenu', e => { e.preventDefault(); if (input.buildMode) { input.buildMode = null; buildTip.style.display = 'none'; } });
-      window.addEventListener('keydown', e => { const k = e.key.toLowerCase(); input.keys[k] = true; if (k === 'f') globalThis.fogEnabled = !globalThis.fogEnabled; if (k === '1') tryCast(1); if (k === '2') tryCast(2); if (k === '3') tryCast(3); if (k === 'u') { const h = players[0].hero; if (h && h.inventory.length) { const it = h.inventory.shift(); applyItem(h, it); renderInventory(h); } } if (k === 'r') { resumeWorkers(players[0]); } });
+      window.addEventListener('keydown', e => { const k = e.key.toLowerCase(); input.keys[k] = true; if (k === 'f') setFogEnabled(!fogEnabled); if (k === '1') tryCast(1); if (k === '2') tryCast(2); if (k === '3') tryCast(3); if (k === 'u') { const h = players[0].hero; if (h && h.inventory.length) { const it = h.inventory.shift(); applyItem(h, it); renderInventory(h); } } if (k === 'r') { resumeWorkers(players[0]); } });
       window.addEventListener('keyup', e => { input.keys[e.key.toLowerCase()] = false; });
 
       function entityAt(wx, wy) {
@@ -277,7 +288,6 @@ globalThis.beep = beep;
       function allStructures() { return players[0].structures.concat(players[1].structures, players[2].structures); }
       function nearestNode(type, P) { const arr = (type === 'rice' ? riceNodes : waterNodes); let best = null, bd = 1e9; for (const n of arr) { const d = dist2(P.structures[0].x, P.structures[0].y, n.x, n.y); if (d < bd) { bd = d; best = n; } } return best; }
       function lootFromTier(t) { const base = ['scroll_hp', 'scroll_dps']; const rare = ['ring_atk', 'boots', 'amulet', 'orb']; return (Math.random() < 0.6 ? base[Math.random() < 0.5 ? 0 : 1] : rare[(Math.random() * rare.length) | 0]); }
-Object.assign(globalThis, { players, neutral, drops, riceNodes, waterNodes, COSTS, POP_CAP, resUI, updateRes, placeGhost, renderWorkerBuildPanel, updateBuildingPanel, resumeWorkers, statsPanel, updateStatsPanel, drawMinimap, allUnits, allStructures, nearestNode, lootFromTier, input });
 
       await import("./ui.js");
 await import("./terrain.js");
@@ -305,7 +315,6 @@ await import("./ai.js");
         world.camX = players[0].structures[0].x - 400; world.camY = players[0].structures[0].y - 300;
       }
       resetGame();
-globalThis.resetGame = resetGame;
 
       /* ==== Loot & pickup ==== */
       function tryPickup() { for (const p of players) { const h = p.hero; if (h && !h.dead) { for (const d of drops) { if (!d.dead && Math.sqrt(dist2(d.x, d.y, h.x, h.y)) < 28) { if (h.inventory.length < 6) { h.inventory.push(d.kind); d.dead = true; if (p === players[0]) renderInventory(h); } } } } } }
@@ -316,7 +325,7 @@ globalThis.resetGame = resetGame;
       function loop(t) {
         const dt = Math.min(0.033, (t - last) / 1000); last = t; simTime += dt;
         clearVisible(); for (const s of players[0].structures) revealCircle(s.x, s.y, 520); for (const u of players[0].units) revealCircle(u.x, u.y, 480);
-        if (!globalThis.paused) {
+        if (!paused) {
           const sp = 900 / world.zoom; if (input.keys['w'] || input.keys['ц']) world.camY -= sp * dt; if (input.keys['s'] || input.keys['ы']) world.camY += sp * dt; if (input.keys['a'] || input.keys['ф']) world.camX -= sp * dt; if (input.keys['d'] || input.keys['в']) world.camX += sp * dt;
           for (const p of players) { for (const s of p.structures) s.update(dt); for (const u of p.units) u.update(dt); if (p.ai) aiThink(dt, players.indexOf(p)); }
           for (const n of neutral.units) { n.update(dt); if (n.dead && !n.awarded) { if (n.lastHitBy != null && n.lastHitBy >= 0) { heroGainFromNeutral(n.lastHitBy, n.tier); if (Math.random() < 0.5) { drops.push(new ItemDrop(n.x + rand(-10, 10), n.y + rand(-10, 10), lootFromTier(n.tier))); } } n.awarded = true; } }
@@ -354,4 +363,12 @@ globalThis.resetGame = resetGame;
       });
 
       function startBuild(kind) { input.buildMode = kind; document.getElementById('buildTip').style.display = 'block'; }
-globalThis.startBuild = startBuild;
+
+export {
+  clamp, rand, dist2, cvs, ctx, mini, mctx, DPR, world, screenToWorld, worldToScreen,
+  paused, muted, fogEnabled, setPaused, setMuted, setFogEnabled,
+  beep, players, neutral, drops, riceNodes, waterNodes, COSTS, POP_CAP, resUI, updateRes,
+  placeGhost, renderWorkerBuildPanel, updateBuildingPanel, resumeWorkers, statsPanel,
+  updateStatsPanel, drawMinimap, allUnits, allStructures, nearestNode, lootFromTier, input,
+  resetGame, startBuild
+};

--- a/src/terrain.js
+++ b/src/terrain.js
@@ -1,8 +1,9 @@
 /* ==== Simple terrain + blockers (лес/река) ==== */
 // Генерим «реки» (непроходимые) как вертикальные полосы и «лес» как кучки препятствий
-const blockers = []; // {x,y,r}
-function genBlockers() {
-  const { rand, clamp, world } = globalThis;
+import { rand, clamp, world, ctx, cvs, worldToScreen, dist2 } from './main.js';
+
+export const blockers = []; // {x,y,r}
+export function genBlockers() {
   blockers.length = 0;
   for (let i = 0; i < 4; i++) {
     const x = 2000 + i * 2500 + rand(-400, 400);
@@ -14,8 +15,7 @@ function genBlockers() {
     blockers.push({ x: rand(600, world.width - 600), y: rand(600, world.height - 600), r: clamp(rand(24, 60), 24, 60) });
   }
 }
-function drawTerrain() {
-  const { ctx, world, cvs, worldToScreen } = globalThis;
+export function drawTerrain() {
   ctx.save(); ctx.scale(world.zoom, world.zoom);
   const step = 96;
   const startX = Math.floor(world.camX / step) * step,
@@ -39,11 +39,9 @@ function drawTerrain() {
   }
   ctx.restore();
 }
-function isBlocked(wx, wy) {
-  const { dist2 } = globalThis;
+export function isBlocked(wx, wy) {
   for (const b of blockers) {
     if (dist2(wx, wy, b.x, b.y) <= (b.r + 10) * (b.r + 10)) return true;
   }
   return false;
 }
-Object.assign(globalThis, { blockers, genBlockers, drawTerrain, isBlocked });

--- a/src/ui.js
+++ b/src/ui.js
@@ -1,4 +1,6 @@
 /* ==== Menu & toggles ==== */
+import { paused, muted, fogEnabled, setPaused, setMuted, setFogEnabled, resetGame } from './main.js';
+
 const menu = document.getElementById('menu');
 const btnStart = document.getElementById('btnStart');
 const btnRestart = document.getElementById('btnRestart');
@@ -6,12 +8,8 @@ const btnMute = document.getElementById('btnMute');
 const btnPause = document.getElementById('btnPause');
 const btnFog = document.getElementById('btnFog');
 
-globalThis.paused = true;
-globalThis.muted = false;
-globalThis.fogEnabled = true;
-
-btnStart.onclick = () => { globalThis.paused = false; menu.style.display = 'none'; };
-btnRestart.onclick = () => { resetGame(); globalThis.paused = false; menu.style.display = 'none'; };
-btnMute.onclick = () => { globalThis.muted = !globalThis.muted; btnMute.textContent = globalThis.muted ? 'Звук: выкл' : 'Звук: вкл'; };
-btnPause.onclick = () => { globalThis.paused = !globalThis.paused; menu.style.display = globalThis.paused ? 'flex' : 'none'; };
-btnFog.onclick = () => { globalThis.fogEnabled = !globalThis.fogEnabled; btnFog.textContent = globalThis.fogEnabled ? 'No Fog' : 'Fog'; };
+btnStart.onclick = () => { setPaused(false); menu.style.display = 'none'; };
+btnRestart.onclick = () => { resetGame(); setPaused(false); menu.style.display = 'none'; };
+btnMute.onclick = () => { setMuted(!muted); btnMute.textContent = muted ? 'Звук: выкл' : 'Звук: вкл'; };
+btnPause.onclick = () => { setPaused(!paused); menu.style.display = paused ? 'flex' : 'none'; };
+btnFog.onclick = () => { setFogEnabled(!fogEnabled); btnFog.textContent = fogEnabled ? 'No Fog' : 'Fog'; };


### PR DESCRIPTION
## Summary
- export helpers and game state from main.js instead of attaching to globalThis
- import shared symbols in AI, terrain, fog and UI modules
- add state setters so modules no longer rely on global state

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ca70d93dc83278401cd3d7790264e