### PR TITLE
Refactor AI plan and improve neutral camp targeting

### DIFF
--- a/src/ai.js
+++ b/src/ai.js
@@ -1,9 +1,29 @@
 /* ==== AI ==== */
 function aiInitPlan(P) {
-  const cls = P.hero.heroClass;
-  if (cls === 'paladin') { P.aiPlan = { comp: { soldier: 0.6, archer: 0.4, mage: 0.0 }, open: ['well', 'barracks', 'range'], state: 'farm', pushAt: 10, nextBuild: 0 }; }
-  else if (cls === 'rogue') { P.aiPlan = { comp: { soldier: 0.4, archer: 0.6, mage: 0.0 }, open: ['well', 'range', 'barracks'], state: 'farm', pushAt: 8, nextBuild: 0 }; }
-  else { P.aiPlan = { comp: { soldier: 0.2, archer: 0.4, mage: 0.4 }, open: ['well', 'mBarracks', 'range'], state: 'farm', pushAt: 12, nextBuild: 0 }; }
+  const cls = P.hero && P.hero.heroClass;
+  const plans = {
+    paladin: {
+      comp: { soldier: 0.6, archer: 0.4, mage: 0.0 },
+      open: ['well', 'barracks', 'range'],
+      state: 'farm',
+      pushAt: 10,
+      nextBuild: 0,
+    },
+    rogue: {
+      comp: { soldier: 0.4, archer: 0.6, mage: 0.0 },
+      open: ['well', 'range', 'barracks'],
+      state: 'farm',
+      pushAt: 8,
+      nextBuild: 0,
+    },
+  };
+  P.aiPlan = plans[cls] || {
+    comp: { soldier: 0.2, archer: 0.4, mage: 0.4 },
+    open: ['well', 'mBarracks', 'range'],
+    state: 'farm',
+    pushAt: 12,
+    nextBuild: 0,
+  };
 }
 function aiThink(dt, id) {
   const players = globalThis.players;
@@ -61,12 +81,18 @@ function nearestNeutralCamp(P) {
     console.warn('nearestNeutralCamp: no structures available');
     return null;
   }
-  let best = null, bd = 1e9;
+  if (!neutral || !Array.isArray(neutral.units) || neutral.units.length === 0) {
+    console.warn('nearestNeutralCamp: no neutral units');
+    return null;
+  }
+  const origin = P.structures[0];
+  let best = null;
+  let bestDist = Infinity;
   for (const n of neutral.units) {
     if (n.dead) continue;
-    const d = dist2(P.structures[0].x, P.structures[0].y, n.x, n.y);
-    if (d < bd) {
-      bd = d;
+    const d = dist2(origin.x, origin.y, n.x, n.y);
+    if (d < bestDist) {
+      bestDist = d;
       best = n;
     }
   }

--- a/test/ai.test.js
+++ b/test/ai.test.js
@@ -3,12 +3,37 @@ require('../src/ai.js');
 globalThis.neutral = { units: [] };
 globalThis.dist2 = (x1, y1, x2, y2) => (x1 - x2) ** 2 + (y1 - y2) ** 2;
 
+// no structures
 const P = { structures: [] };
-
-const result = globalThis.nearestNeutralCamp(P);
+let result = globalThis.nearestNeutralCamp(P);
 if (result === null) {
   console.log('nearestNeutralCamp returned null when no structures: OK');
 } else {
   console.error('nearestNeutralCamp did not return null');
+  process.exit(1);
+}
+
+// no neutral units
+globalThis.neutral.units = [];
+const P2 = { structures: [{ x: 0, y: 0 }] };
+result = globalThis.nearestNeutralCamp(P2);
+if (result === null) {
+  console.log('nearestNeutralCamp returned null when no neutral units: OK');
+} else {
+  console.error('nearestNeutralCamp did not handle empty neutral units');
+  process.exit(1);
+}
+
+// chooses nearest
+globalThis.neutral.units = [
+  { x: 10, y: 0, dead: false },
+  { x: 3, y: 4, dead: false },
+];
+const P3 = { structures: [{ x: 0, y: 0 }] };
+result = globalThis.nearestNeutralCamp(P3);
+if (result === globalThis.neutral.units[1]) {
+  console.log('nearestNeutralCamp returned nearest camp: OK');
+} else {
+  console.error('nearestNeutralCamp did not return nearest camp');
   process.exit(1);
 }


### PR DESCRIPTION
## Summary
- Refactor aiInitPlan using class-based plans and hero safety checks
- Handle empty neutral camps in nearestNeutralCamp and choose closest target
- Expand tests for edge cases and selection accuracy

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689caeb15c5c832792c9298431e72060