### PR TITLE
Export AI helpers and decouple tests from global state

### DIFF
--- a/src/ai.js
+++ b/src/ai.js
@@ -31,6 +31,8 @@ function aiThink(dt, id) {
   const POP_CAP = globalThis.POP_CAP;
   const placeGhost = globalThis.placeGhost;
   const isBlocked = globalThis.isBlocked;
+  const neutral = globalThis.neutral;
+  const dist2 = globalThis.dist2;
   if (!players[id].ai) return;
   if (!players[id].aiPlan) aiInitPlan(players[id]);
   const P = players[id];
@@ -59,10 +61,9 @@ function aiThink(dt, id) {
     else if (mb) mb.queue.push('mage');
   }
   // hero farms nearest neutral
-  const neutral = globalThis.neutral;
   const hero = P.hero;
   if (hero && !hero.dead) {
-    const tgt = nearestNeutralCamp(P);
+    const tgt = nearestNeutralCamp(P, neutral, dist2);
     if (tgt) {
       hero.setTarget(tgt);
     }
@@ -74,9 +75,7 @@ function aiThink(dt, id) {
     if (tgt) { P.units.filter(u => u.type !== 'worker').forEach(u => { if (!u.retreat) u.setTarget(tgt); }); }
   }
 }
-function nearestNeutralCamp(P) {
-  const neutral = globalThis.neutral;
-  const { dist2 } = globalThis;
+function nearestNeutralCamp(P, neutral, dist2) {
   if (!P.structures.length) {
     console.warn('nearestNeutralCamp: no structures available');
     return null;
@@ -98,4 +97,4 @@ function nearestNeutralCamp(P) {
   }
   return best;
 }
-Object.assign(globalThis, { aiInitPlan, aiThink, nearestNeutralCamp });
+module.exports = { aiInitPlan, aiThink, nearestNeutralCamp };

--- a/test/ai.test.js
+++ b/test/ai.test.js
@@ -1,11 +1,11 @@
-require('../src/ai.js');
+const { nearestNeutralCamp } = require('../src/ai.js');
 
-globalThis.neutral = { units: [] };
-globalThis.dist2 = (x1, y1, x2, y2) => (x1 - x2) ** 2 + (y1 - y2) ** 2;
+const neutral = { units: [] };
+const dist2 = (x1, y1, x2, y2) => (x1 - x2) ** 2 + (y1 - y2) ** 2;
 
 // no structures
 const P = { structures: [] };
-let result = globalThis.nearestNeutralCamp(P);
+let result = nearestNeutralCamp(P, neutral, dist2);
 if (result === null) {
   console.log('nearestNeutralCamp returned null when no structures: OK');
 } else {
@@ -14,9 +14,9 @@ if (result === null) {
 }
 
 // no neutral units
-globalThis.neutral.units = [];
+neutral.units = [];
 const P2 = { structures: [{ x: 0, y: 0 }] };
-result = globalThis.nearestNeutralCamp(P2);
+result = nearestNeutralCamp(P2, neutral, dist2);
 if (result === null) {
   console.log('nearestNeutralCamp returned null when no neutral units: OK');
 } else {
@@ -25,13 +25,13 @@ if (result === null) {
 }
 
 // chooses nearest
-globalThis.neutral.units = [
+neutral.units = [
   { x: 10, y: 0, dead: false },
   { x: 3, y: 4, dead: false },
 ];
 const P3 = { structures: [{ x: 0, y: 0 }] };
-result = globalThis.nearestNeutralCamp(P3);
-if (result === globalThis.neutral.units[1]) {
+result = nearestNeutralCamp(P3, neutral, dist2);
+if (result === neutral.units[1]) {
   console.log('nearestNeutralCamp returned nearest camp: OK');
 } else {
   console.error('nearestNeutralCamp did not return nearest camp');


### PR DESCRIPTION
## Summary
- export `aiInitPlan`, `aiThink`, and `nearestNeutralCamp` via `module.exports`
- refactor `nearestNeutralCamp` to accept neutral state and distance function as parameters
- update tests to import helpers with destructuring and avoid using `globalThis`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cb0ad102c8327b81ade2ec2ce6648