### PR TITLE
Refactor AI tests to use assert

### DIFF
--- a/test/ai.test.js
+++ b/test/ai.test.js
@@ -1,39 +1,48 @@
+const assert = require('assert');
 const { nearestNeutralCamp } = require('../src/ai.js');
 
-const neutral = { units: [] };
 const dist2 = (x1, y1, x2, y2) => (x1 - x2) ** 2 + (y1 - y2) ** 2;
 
 // no structures
-const P = { structures: [] };
-let result = nearestNeutralCamp(P, neutral, dist2);
-if (result === null) {
-  console.log('nearestNeutralCamp returned null when no structures: OK');
-} else {
-  console.error('nearestNeutralCamp did not return null');
-  process.exit(1);
-}
+(() => {
+  const neutral = { units: [] };
+  const P = { structures: [] };
+  const result = nearestNeutralCamp(P, neutral, dist2);
+  assert.strictEqual(result, null);
+})();
 
 // no neutral units
-neutral.units = [];
-const P2 = { structures: [{ x: 0, y: 0 }] };
-result = nearestNeutralCamp(P2, neutral, dist2);
-if (result === null) {
-  console.log('nearestNeutralCamp returned null when no neutral units: OK');
-} else {
-  console.error('nearestNeutralCamp did not handle empty neutral units');
-  process.exit(1);
-}
+(() => {
+  const neutral = { units: [] };
+  const P = { structures: [{ x: 0, y: 0 }] };
+  const result = nearestNeutralCamp(P, neutral, dist2);
+  assert.strictEqual(result, null);
+})();
 
 // chooses nearest
-neutral.units = [
-  { x: 10, y: 0, dead: false },
-  { x: 3, y: 4, dead: false },
-];
-const P3 = { structures: [{ x: 0, y: 0 }] };
-result = nearestNeutralCamp(P3, neutral, dist2);
-if (result === neutral.units[1]) {
-  console.log('nearestNeutralCamp returned nearest camp: OK');
-} else {
-  console.error('nearestNeutralCamp did not return nearest camp');
-  process.exit(1);
-}
+(() => {
+  const neutral = {
+    units: [
+      { x: 10, y: 0, dead: false },
+      { x: 3, y: 4, dead: false },
+    ],
+  };
+  const P = { structures: [{ x: 0, y: 0 }] };
+  const result = nearestNeutralCamp(P, neutral, dist2);
+  assert.ok(result === neutral.units[1]);
+})();
+
+// all neutral camps dead
+(() => {
+  const neutral = {
+    units: [
+      { x: 10, y: 0, dead: true },
+      { x: 3, y: 4, dead: true },
+    ],
+  };
+  const P = { structures: [{ x: 0, y: 0 }] };
+  const result = nearestNeutralCamp(P, neutral, dist2);
+  assert.strictEqual(result, null);
+})();
+
+console.log('All tests passed.');


### PR DESCRIPTION
## Summary
- use Node's assert module for nearestNeutralCamp tests
- add coverage for scenario where all neutral camps are dead

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cb20c44a88327b15c5a5ad3ba796d