### PR TITLE
Add simple pixel sprites

### DIFF
--- a/src/entities.js
+++ b/src/entities.js
@@ -201,14 +201,8 @@ export class Unit extends Entity {
   draw() {
     if (this.owner !== 0 && !globalThis.isVisible(this.x, this.y)) return;
     const s = globalThis.worldToScreen(this.x, this.y);
-    let col = '#6bb0ff';
-    if (this.owner === 1) col = '#e05dff';
-    if (this.owner === 2) col = '#ffd27a';
-    if (this.owner === -1) col = '#9fb2a1';
-    globalThis.ctx.fillStyle = col;
-    globalThis.ctx.beginPath();
-    globalThis.ctx.arc(s.x, s.y, 10 * globalThis.world.zoom, 0, 6.283);
-    globalThis.ctx.fill();
+    const col = globalThis.players[this.owner]?.color || '#9fb2a1';
+    globalThis.drawSprite('unit', s.x, s.y, globalThis.world.zoom * 1.25, { o: col });
     globalThis.drawHp(s.x, s.y - 18 * globalThis.world.zoom, this.hp / this.maxHp);
     if (this.isHero) {
       globalThis.ctx.strokeStyle = '#ffd27a';
@@ -261,9 +255,10 @@ export class Structure extends Entity {
   draw() {
     if (this.owner !== 0 && !globalThis.isVisible(this.x, this.y)) return;
     const s = globalThis.worldToScreen(this.x, this.y);
-    globalThis.ctx.fillStyle = this.kind === 'hq' ? '#6f8' : this.kind === 'barracks' ? '#f86' : this.kind === 'range' ? '#cfa' : this.kind === 'mBarracks' ? '#9bf' : '#acf';
-    const w = 84 * globalThis.world.zoom;
-    globalThis.ctx.fillRect(s.x - w / 2, s.y - w / 2, w, w);
+    const col = globalThis.players[this.owner]?.color || '#9fb2a1';
+    const scale = globalThis.world.zoom * 5.25;
+    const w = 16 * scale;
+    globalThis.drawSprite('building', s.x, s.y, scale, { o: col });
     globalThis.drawHp(s.x, s.y - w / 2 - 10, this.hp / this.maxHp);
     if (this.selected) {
       globalThis.ctx.strokeStyle = '#7ac8ff';
@@ -283,18 +278,8 @@ export class ResourceNode {
   draw() {
     if (!globalThis.isExplored(this.x, this.y)) return;
     const s = globalThis.worldToScreen(this.x, this.y);
-    const r = this.radius * globalThis.world.zoom;
-    if (this.type === 'rice') {
-      globalThis.ctx.fillStyle = '#2a4e2a';
-      globalThis.ctx.beginPath();
-      globalThis.ctx.arc(s.x, s.y, r, 0, 6.283);
-      globalThis.ctx.fill();
-    } else {
-      globalThis.ctx.fillStyle = '#1a4e6e';
-      globalThis.ctx.beginPath();
-      globalThis.ctx.arc(s.x, s.y, r, 0, 6.283);
-      globalThis.ctx.fill();
-    }
+    const scale = globalThis.world.zoom * (this.radius * 2 / 16);
+    globalThis.drawSprite(this.type === 'rice' ? 'rice' : 'water', s.x, s.y, scale);
   }
 }
 
@@ -308,10 +293,8 @@ export class ItemDrop extends Entity {
     if (!globalThis.isExplored(this.x, this.y)) return;
     const s = globalThis.worldToScreen(this.x, this.y);
     const map = { scroll_hp: 'HP', scroll_dps: 'DPS', ring_atk: 'Ring', boots: 'Boots', amulet: 'Amul', orb: 'Orb' };
-    globalThis.ctx.fillStyle = (this.kind === 'scroll_hp') ? '#7cff97' : (this.kind === 'scroll_dps' ? '#ffd27a' : '#8ad');
-    globalThis.ctx.beginPath();
-    globalThis.ctx.arc(s.x, s.y - 10, 10 * globalThis.world.zoom, 0, 6.283);
-    globalThis.ctx.fill();
+    const col = (this.kind === 'scroll_hp') ? '#7cff97' : (this.kind === 'scroll_dps' ? '#ffd27a' : '#8ad');
+    globalThis.drawSprite('item', s.x, s.y - 10 * globalThis.world.zoom, globalThis.world.zoom * 1.25, { r: col, R: col });
     globalThis.ctx.fillStyle = '#000';
     globalThis.ctx.font = `${12 * globalThis.world.zoom}px system-ui`;
     globalThis.ctx.fillText(map[this.kind] || this.kind, s.x - 16 * globalThis.world.zoom, s.y + 14 * globalThis.world.zoom);
@@ -371,10 +354,8 @@ export class NeutralCreep extends Entity {
   draw() {
     if (!globalThis.isExplored(this.x, this.y)) return;
     const s = globalThis.worldToScreen(this.x, this.y);
-    globalThis.ctx.fillStyle = this.tier >= 3 ? '#b86' : (this.tier == 2 ? '#a68' : '#9fb2a1');
-    globalThis.ctx.beginPath();
-    globalThis.ctx.arc(s.x, s.y, 12 * globalThis.world.zoom, 0, 6.283);
-    globalThis.ctx.fill();
+    const col = this.tier >= 3 ? '#b86' : (this.tier === 2 ? '#a68' : '#9fb2a1');
+    globalThis.drawSprite('unit', s.x, s.y, globalThis.world.zoom * 1.25, { o: col });
     globalThis.drawHp(s.x, s.y - 18 * globalThis.world.zoom, this.hp / this.maxHp);
   }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -1,3 +1,4 @@
+import "./sprites.js";
 import { Unit, Structure, ResourceNode, ItemDrop, NeutralCreep, getById, enemiesFor, allUnits, allStructures, nearestNode, lootFromTier } from "./entities.js";
 
 /* ==== Helpers ==== */

--- a/src/sprites.js
+++ b/src/sprites.js
@@ -1,0 +1,162 @@
+/* Simple pixel sprites and drawing helper */
+const PALETTE = {
+  g: '#3b7a3b',
+  G: '#2e642e',
+  w: '#83b9d4',
+  W: '#5a9bb7',
+  r: '#cddc39',
+  R: '#a0b020',
+  t: '#5d3a1a',
+  T: '#2e7d32',
+  s: '#f1c27d',
+  b: '#8b5a2b'
+};
+
+const SPRITES = {
+  grass: [
+    "gGgggGggggGggggg",
+    "gggggGgggggggggg",
+    "gggGggggggGggggg",
+    "gggggggggggggggg",
+    "gGggggggggggGggg",
+    "gggggggggggggggg",
+    "gggggGgggggggggg",
+    "ggggggggGggggggg",
+    "gggggggggggggggg",
+    "gggGgggggGgggggg",
+    "gggggggggggggggg",
+    "gggggggggggggggg",
+    "gggggggggGgggggg",
+    "gggggggggggggggg",
+    "gggggggggggggggg",
+    "gggggggggggggggg"
+  ],
+  water: [
+    "wwWWwwWWwwWWwwWW",
+    "WWwwWWwwWWwwWWww",
+    "wwWWwwWWwwWWwwWW",
+    "WWwwWWwwWWwwWWww",
+    "wwWWwwWWwwWWwwWW",
+    "WWwwWWwwWWwwWWww",
+    "wwWWwwWWwwWWwwWW",
+    "WWwwWWwwWWwwWWww",
+    "wwWWwwWWwwWWwwWW",
+    "WWwwWWwwWWwwWWww",
+    "wwWWwwWWwwWWwwWW",
+    "WWwwWWwwWWwwWWww",
+    "wwWWwwWWwwWWwwWW",
+    "WWwwWWwwWWwwWWww",
+    "wwWWwwWWwwWWwwWW",
+    "WWwwWWwwWWwwWWww"
+  ],
+  rice: [
+    "rrrrrrrrrrrrrrrr",
+    "rRrRrRrRrRrRrRrR",
+    "rrrrrrrrrrrrrrrr",
+    "rRrRrRrRrRrRrRrR",
+    "rrrrrrrrrrrrrrrr",
+    "rRrRrRrRrRrRrRrR",
+    "rrrrrrrrrrrrrrrr",
+    "rRrRrRrRrRrRrRrR",
+    "rrrrrrrrrrrrrrrr",
+    "rRrRrRrRrRrRrRrR",
+    "rrrrrrrrrrrrrrrr",
+    "rRrRrRrRrRrRrRrR",
+    "rrrrrrrrrrrrrrrr",
+    "rRrRrRrRrRrRrRrR",
+    "rrrrrrrrrrrrrrrr",
+    "rRrRrRrRrRrRrRrR"
+  ],
+  tree: [
+    ".......T.......",
+    "......TTT......",
+    ".....TTTTT.....",
+    "....TTTTTTT....",
+    "...TTTTTTTTT...",
+    "..TTTTTTTTTTT..",
+    "...TTTTTTTTT...",
+    "....TTTTTTT....",
+    ".......T.......",
+    ".......T.......",
+    ".......T.......",
+    ".......T.......",
+    "......TTT......",
+    "......TTT......",
+    "......TTT......",
+    "......TTT......"
+  ],
+  unit: [
+    "................",
+    ".......s........",
+    "......sss.......",
+    "......sss.......",
+    ".......s........",
+    "....ooooooo.....",
+    "...ooooooooo....",
+    "...ooooooooo....",
+    "...ooooooooo....",
+    "...ooooooooo....",
+    "....ooooooo.....",
+    ".......o........",
+    "......o.o.......",
+    ".....o...o......",
+    "................",
+    "................"
+  ],
+  item: [
+    "................",
+    "....rrrrrr......",
+    "...rRRRRRRr.....",
+    "..rR......Rr....",
+    "..rR......Rr....",
+    "...rRRRRRRr.....",
+    "....rrrrrr......",
+    "................",
+    "................",
+    "................",
+    "................",
+    "................",
+    "................",
+    "................",
+    "................",
+    "................"
+  ],
+  building: [
+    "bbbbbbbbbbbbbbbb",
+    "boooooooooooooob",
+    "bo............ob",
+    "bo............ob",
+    "bo............ob",
+    "bo............ob",
+    "bo............ob",
+    "bbbbbbbbbbbbbbbb",
+    "boooooooooooooob",
+    "bo............ob",
+    "bo............ob",
+    "bo............ob",
+    "bo............ob",
+    "boooooooooooooob",
+    "bbbbbbbbbbbbbbbb",
+    "................"
+  ]
+};
+
+function drawSprite(name, x, y, scale = 1, override = {}) {
+  const spr = SPRITES[name];
+  if (!spr) return;
+  const h = spr.length;
+  const w = spr[0].length;
+  const ctx = globalThis.ctx;
+  for (let j = 0; j < h; j++) {
+    const row = spr[j];
+    for (let i = 0; i < w; i++) {
+      const ch = row[i];
+      if (ch === '.') continue;
+      const color = override[ch] || PALETTE[ch] || '#000';
+      ctx.fillStyle = color;
+      ctx.fillRect(x + (i - w / 2) * scale, y + (j - h / 2) * scale, scale, scale);
+    }
+  }
+}
+
+Object.assign(globalThis, { drawSprite });

--- a/src/terrain.js
+++ b/src/terrain.js
@@ -1,43 +1,38 @@
 /* ==== Simple terrain + blockers (лес/река) ==== */
 // Генерим «реки» (непроходимые) как вертикальные полосы и «лес» как кучки препятствий
-const blockers = []; // {x,y,r}
+const blockers = []; // {x,y,r,kind}
 function genBlockers() {
   const { rand, clamp, world } = globalThis;
   blockers.length = 0;
   for (let i = 0; i < 4; i++) {
     const x = 2000 + i * 2500 + rand(-400, 400);
     for (let y = 600; y < world.height - 600; y += 180) {
-      blockers.push({ x: x + rand(-60, 60), y: y, r: 38 });
+      blockers.push({ x: x + rand(-60, 60), y: y, r: 38, kind: 'water' });
     }
   }
   for (let i = 0; i < 70; i++) {
-    blockers.push({ x: rand(600, world.width - 600), y: rand(600, world.height - 600), r: clamp(rand(24, 60), 24, 60) });
+    blockers.push({ x: rand(600, world.width - 600), y: rand(600, world.height - 600), r: clamp(rand(24, 60), 24, 60), kind: 'tree' });
   }
 }
 function drawTerrain() {
-  const { ctx, world, cvs, worldToScreen } = globalThis;
-  ctx.save(); ctx.scale(world.zoom, world.zoom);
-  const step = 96;
+  const { world, cvs, worldToScreen } = globalThis;
+  const step = 64;
   const startX = Math.floor(world.camX / step) * step,
         startY = Math.floor(world.camY / step) * step,
         endX = world.camX + cvs.width / world.zoom,
         endY = world.camY + cvs.height / world.zoom;
   for (let y = startY; y <= endY; y += step) {
     for (let x = startX; x <= endX; x += step) {
-      const h = ((Math.sin(x * 0.0006) + Math.cos(y * 0.0007)) * 0.5 + 0.5);
-      let r = 18, g = 58, b = 20; if (h > 0.9) { r = 80; g = 82; b = 90; }
-      ctx.fillStyle = `rgb(${r},${g},${b})`;
-      ctx.fillRect(x - world.camX, y - world.camY, step, step);
+      const s = worldToScreen(x + step / 2, y + step / 2);
+      globalThis.drawSprite('grass', s.x, s.y, world.zoom * 4);
     }
   }
   // реки/лес
   for (const b of blockers) {
     const s = worldToScreen(b.x, b.y);
-    ctx.fillStyle = 'rgba(30,80,120,.9)'; ctx.beginPath();
-    ctx.arc(s.x, s.y, b.r * world.zoom, 0, 6.283); ctx.fill();
-    ctx.strokeStyle = 'rgba(0,0,0,.35)'; ctx.stroke();
+    const sc = world.zoom * (b.r / 8);
+    globalThis.drawSprite(b.kind === 'water' ? 'water' : 'tree', s.x, s.y, sc);
   }
-  ctx.restore();
 }
 function isBlocked(wx, wy) {
   const { dist2 } = globalThis;


### PR DESCRIPTION
## Summary
- add basic sprite definitions and draw helper
- render terrain with grass, water and tree sprites
- draw units, structures and resources using pixel sprites

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cb9a4a8d88327b96f63b982503806