### PR TITLE
Fix global references for browser usage

### DIFF
--- a/src/ai.js
+++ b/src/ai.js
@@ -97,4 +97,10 @@ function nearestNeutralCamp(P, neutral, dist2) {
   }
   return best;
 }
-module.exports = { aiInitPlan, aiThink, nearestNeutralCamp };
+  if (typeof module !== 'undefined' && module.exports) {
+    // Node.js/TEST environment
+    module.exports = { aiInitPlan, aiThink, nearestNeutralCamp };
+  } else {
+    // Browser environment - expose to global scope
+    Object.assign(globalThis, { aiInitPlan, aiThink, nearestNeutralCamp });
+  }

--- a/src/ui.js
+++ b/src/ui.js
@@ -11,7 +11,7 @@ globalThis.muted = false;
 globalThis.fogEnabled = true;
 
 btnStart.onclick = () => { globalThis.paused = false; menu.style.display = 'none'; };
-btnRestart.onclick = () => { resetGame(); globalThis.paused = false; menu.style.display = 'none'; };
+  btnRestart.onclick = () => { globalThis.resetGame(); globalThis.paused = false; menu.style.display = 'none'; };
 btnMute.onclick = () => { globalThis.muted = !globalThis.muted; btnMute.textContent = globalThis.muted ? 'Звук: выкл' : 'Звук: вкл'; };
 btnPause.onclick = () => { globalThis.paused = !globalThis.paused; menu.style.display = globalThis.paused ? 'flex' : 'none'; };
 btnFog.onclick = () => { globalThis.fogEnabled = !globalThis.fogEnabled; btnFog.textContent = globalThis.fogEnabled ? 'No Fog' : 'Fog'; };


### PR DESCRIPTION
## Summary
- Avoid `module is not defined` error in browsers by conditionally exporting AI functions
- Call `resetGame` via `globalThis` in restart button

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cbcee8dcc83279a2243703a965b50