### PR TITLE
Implement mana regeneration with tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A simple static HTML page project.",
   "main": "index.js",
   "scripts": {
-    "test": "node test/ai.test.js"
+    "test": "node test/ai.test.js && node test/mp-regen.test.js"
   },
   "repository": {
     "type": "git",

--- a/src/entities.js
+++ b/src/entities.js
@@ -49,6 +49,7 @@ export class Unit extends Entity {
     this.isHero = false;
     this.mp = 0;
     this.maxMp = 0;
+    this.mpRegen = 0;
     this.cd1 = 0;
     this.cd2 = 0;
     this.cd3 = 0;
@@ -172,6 +173,9 @@ export class Unit extends Entity {
     if (this.dead) return;
     if (this.hp < this.maxHp) {
       this.hp = Math.min(this.maxHp, this.hp + this.regen * dt * 60);
+    }
+    if (this.mp < this.maxMp) {
+      this.mp = Math.min(this.maxMp, this.mp + this.mpRegen * dt * 60);
     }
     this.cd1 = Math.max(0, this.cd1 - dt);
     this.cd2 = Math.max(0, this.cd2 - dt);

--- a/src/main.js
+++ b/src/main.js
@@ -62,7 +62,7 @@ let simTime = 0;
       function setHeroUI(h) { if (!h) { abilityBar.style.display = 'none'; invPanel.style.display = 'none'; return; } abilityBar.style.display = 'block'; invPanel.style.display = 'block'; heroName.textContent = h.heroName + ' (' + h.heroClass + ')'; heroHP.textContent = `HP ${h.hp | 0}/${h.maxHp | 0}`; heroMP.textContent = `MP ${h.mp | 0}/${h.maxMp | 0}`; heroLVL.textContent = 'Lvl ' + h.levelStacks; }
       ab1.onclick = () => tryCast(1); ab2.onclick = () => tryCast(2); ab3.onclick = () => tryCast(3);
       function spawnHero(owner, x, y, cls = null) {
-        const h = new Unit(x, y, owner, 'soldier'); h.isHero = true; h.maxHp = 420; h.hp = 420; h.maxMp = 160; h.mp = 120; h.dps = 50; h.attackRange = 40; h.vision = 560; h.inventory = []; h.levelStacks = 0; h.regen = 1.2;
+        const h = new Unit(x, y, owner, 'soldier'); h.isHero = true; h.maxHp = 420; h.hp = 420; h.maxMp = 160; h.mp = 120; h.dps = 50; h.attackRange = 40; h.vision = 560; h.inventory = []; h.levelStacks = 0; h.regen = 1.2; h.mpRegen = 0.8;
         if (!cls) { const r = Math.random(); cls = r < 0.34 ? 'paladin' : (r < 0.67 ? 'rogue' : 'archmage'); }
         h.heroClass = cls;
         if (cls === 'paladin') { h.heroName = 'Паладин'; h.cdM1 = 8; h.cdM2 = 12; h.cdM3 = 16; }

--- a/test/mp-regen.test.js
+++ b/test/mp-regen.test.js
@@ -1,0 +1,31 @@
+const assert = require('assert');
+const { Unit } = require('../src/entities.js');
+
+global.isBlocked = () => false;
+global.getById = () => null;
+global.enemiesFor = () => [];
+global.dist2 = () => 0;
+global.players = [];
+global.neutral = { units: [] };
+
+// mp regenerates up to max
+(() => {
+  const u = new Unit(0, 0, 0, 'soldier');
+  u.maxMp = 100;
+  u.mp = 50;
+  u.mpRegen = 5; // per frame based on regen formula
+  u.update(1 / 60);
+  assert.ok(Math.abs(u.mp - 55) < 0.0001);
+})();
+
+// mp does not exceed maxMp
+(() => {
+  const u = new Unit(0, 0, 0, 'soldier');
+  u.maxMp = 100;
+  u.mp = 98;
+  u.mpRegen = 5;
+  u.update(1 / 60);
+  assert.strictEqual(u.mp, 100);
+})();
+
+console.log('MP regen tests passed.');


### PR DESCRIPTION
## Summary
- add mpRegen property to units and regenerate mana over time
- give heroes a base mana regeneration rate
- cover mana regeneration with unit tests and include them in npm test script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689cbfe66c4c8327974b149622a98675