### PR TITLE
Improve movement handling, hero info, items and AI

### DIFF
--- a/src/ai.js
+++ b/src/ai.js
@@ -68,11 +68,17 @@ function aiThink(dt, id) {
       hero.setTarget(tgt);
     }
   }
+  // early army neutral farming
+  const army = P.units.filter(u => u.type !== 'worker' && !u.isHero);
+  if (army.length >= 3 && army.length < P.aiPlan.pushAt) {
+    const nt = nearestNeutralCamp(P, neutral, dist2);
+    if (nt) { army.forEach(u => { if (!u.retreat) u.setTarget(nt); }); }
+  }
   // army rally / attack
-  if (P.units.filter(u => u.type !== 'worker' && !u.isHero).length >= P.aiPlan.pushAt) {
+  if (army.length >= P.aiPlan.pushAt) {
     const enemyHero = players[0].hero && !players[0].hero.dead ? players[0].hero : null;
     const tgt = enemyHero || players[0].structures.find(s => !s.isGhost) || players[0].units.find(u => !u.isHero);
-    if (tgt) { P.units.filter(u => u.type !== 'worker').forEach(u => { if (!u.retreat) u.setTarget(tgt); }); }
+    if (tgt) { army.forEach(u => { if (!u.retreat) u.setTarget(tgt); }); }
   }
 }
 function nearestNeutralCamp(P, neutral, dist2) {

--- a/src/entities.js
+++ b/src/entities.js
@@ -1,6 +1,18 @@
 /* ==== Entities ==== */
 let nextId = 1;
 
+function moveEntity(e, dx, dy, v, dt) {
+  const d = Math.hypot(dx, dy);
+  if (d <= 0) return;
+  const nx = e.x + (dx / d) * v * dt, ny = e.y + (dy / d) * v * dt;
+  if (!globalThis.isBlocked(nx, ny)) { e.x = nx; e.y = ny; return; }
+  const ux = -dy / d, uy = dx / d;
+  const sx = e.x + ux * v * dt, sy = e.y + uy * v * dt;
+  if (!globalThis.isBlocked(sx, sy)) { e.x = sx; e.y = sy; return; }
+  const sx2 = e.x - ux * v * dt, sy2 = e.y - uy * v * dt;
+  if (!globalThis.isBlocked(sx2, sy2)) { e.x = sx2; e.y = sy2; }
+}
+
 export class Entity {
   constructor(x, y, owner = -1) {
     this.id = nextId++;
@@ -98,8 +110,7 @@ export class Unit extends Entity {
       const dx = this.destX - this.x, dy = this.destY - this.y, d = Math.hypot(dx, dy);
       if (d > 2) {
         const v = this.getCurrentSpeed();
-        const nx = this.x + dx / d * v * dt, ny = this.y + dy / d * v * dt;
-        if (!globalThis.isBlocked(nx, ny)) { this.x = nx; this.y = ny; }
+        moveEntity(this, dx, dy, v, dt);
       } else {
         this.state = 'harvest';
         this.workTimer = (this.role === 'rice' ? 2.2 : 2.6);
@@ -118,8 +129,7 @@ export class Unit extends Entity {
       const dx = this.destX - this.x, dy = this.destY - this.y, d = Math.hypot(dx, dy);
       if (d > 2) {
         const v = this.getCurrentSpeed();
-        const nx = this.x + dx / d * v * dt, ny = this.y + dy / d * v * dt;
-        if (!globalThis.isBlocked(nx, ny)) { this.x = nx; this.y = ny; }
+        moveEntity(this, dx, dy, v, dt);
       } else {
         if (this.carry > 0) {
           if (this.role === 'rice') P.res.rice += this.carry;
@@ -149,8 +159,7 @@ export class Unit extends Entity {
     const d = Math.hypot(dx, dy);
     if (d > this.attackRange) {
       const v = this.getCurrentSpeed();
-      const nx = this.x + dx / d * v * dt, ny = this.y + dy / d * v * dt;
-      if (!globalThis.isBlocked(nx, ny)) { this.x = nx; this.y = ny; }
+      moveEntity(this, dx, dy, v, dt);
     } else {
       this.attackCd -= dt;
       if (this.attackCd <= 0) {
@@ -165,8 +174,7 @@ export class Unit extends Entity {
     const d = Math.hypot(dx, dy);
     if (d > 2) {
       const v = this.getCurrentSpeed();
-      const nx = this.x + dx / d * v * dt, ny = this.y + dy / d * v * dt;
-      if (!globalThis.isBlocked(nx, ny)) { this.x = nx; this.y = ny; }
+      moveEntity(this, dx, dy, v, dt);
     }
   }
   update(dt) {
@@ -296,7 +304,7 @@ export class ItemDrop extends Entity {
   draw() {
     if (!globalThis.isExplored(this.x, this.y)) return;
     const s = globalThis.worldToScreen(this.x, this.y);
-    const map = { scroll_hp: 'HP', scroll_dps: 'DPS', ring_atk: 'Ring', boots: 'Boots', amulet: 'Amul', orb: 'Orb' };
+    const map = { scroll_hp: 'HP', scroll_dps: 'DPS', ring_atk: 'Mana', boots: 'Boots', amulet: 'Amul', orb: 'Orb' };
     const col = (this.kind === 'scroll_hp') ? '#7cff97' : (this.kind === 'scroll_dps' ? '#ffd27a' : '#8ad');
     globalThis.drawSprite('item', s.x, s.y - 10 * globalThis.world.zoom, globalThis.world.zoom * 1.25, { r: col, R: col });
     globalThis.ctx.fillStyle = '#000';
@@ -336,9 +344,7 @@ export class NeutralCreep extends Entity {
     if (!this.aggro && md < this.leash) this.aggro = true;
     if (this.aggro && tgt && md < this.leash * 1.2) {
       if (md > this.attackRange) {
-        const ux = (tgt.x - this.x) / md, uy = (tgt.y - this.y) / md;
-        const nx = this.x + ux * 80 * dt, ny = this.y + uy * 80 * dt;
-        if (!globalThis.isBlocked(nx, ny)) { this.x = nx; this.y = ny; }
+        moveEntity(this, tgt.x - this.x, tgt.y - this.y, 80, dt);
       } else {
         this.attackCd -= dt;
         if (this.attackCd <= 0) {
@@ -349,8 +355,7 @@ export class NeutralCreep extends Entity {
     } else {
       const dx = this.homeX - this.x, dy = this.homeY - this.y, d = Math.hypot(dx, dy);
       if (d > 2) {
-        const nx = this.x + dx / d * 60 * dt, ny = this.y + dy / d * 60 * dt;
-        if (!globalThis.isBlocked(nx, ny)) { this.x = nx; this.y = ny; }
+        moveEntity(this, dx, dy, 60, dt);
       }
       this.aggro = false;
     }

--- a/src/main.js
+++ b/src/main.js
@@ -59,7 +59,35 @@ let simTime = 0;
 
       /* ==== Hero & abilities ==== */
       const abilityBar = document.getElementById('abilityBar'); const heroName = document.getElementById('heroName'), heroHP = document.getElementById('heroHP'), heroMP = document.getElementById('heroMP'), heroLVL = document.getElementById('heroLVL'); const ab1 = document.getElementById('ab1'), ab2 = document.getElementById('ab2'), ab3 = document.getElementById('ab3'); const invPanel = document.getElementById('invPanel'), invGrid = document.getElementById('invGrid');
-      function setHeroUI(h) { if (!h) { abilityBar.style.display = 'none'; invPanel.style.display = 'none'; return; } abilityBar.style.display = 'block'; invPanel.style.display = 'block'; heroName.textContent = h.heroName + ' (' + h.heroClass + ')'; heroHP.textContent = `HP ${h.hp | 0}/${h.maxHp | 0}`; heroMP.textContent = `MP ${h.mp | 0}/${h.maxMp | 0}`; heroLVL.textContent = 'Lvl ' + h.levelStacks; }
+      const abilityInfo = {
+        paladin: {
+          1: 'Исцеление (40 маны): лечит союзников на 90 HP в радиусе 180.',
+          2: 'Щит (35 маны): даёт 120 щита.',
+          3: 'Святая вспышка (45 маны): лечит союзников на 70 HP и наносит 60 урона врагам в радиусе 200.'
+        },
+        rogue: {
+          1: 'Спринт (25 маны): ускоряет героя на 2.5 с.',
+          2: 'Вихрь (40 маны): наносит 70 урона врагам в радиусе 180.',
+          3: 'Теневой удар (55 маны): наносит 50 урона и замедляет на 3.5 с врагов в радиусе 220.'
+        },
+        archmage: {
+          1: 'Огненный взрыв (35 маны): наносит 80 урона по области 120 в точке указателя.',
+          2: 'Призыв элементаля (60 маны): существо 200 HP, 18 DPS на 20 с.',
+          3: 'Призыв демона (90 маны): существо 500 HP, 36 DPS на 25 с.'
+        }
+      };
+      function setHeroUI(h) {
+        if (!h) { abilityBar.style.display = 'none'; invPanel.style.display = 'none'; return; }
+        abilityBar.style.display = 'block'; invPanel.style.display = 'block';
+        heroName.textContent = h.heroName + ' (' + h.heroClass + ')';
+        heroHP.textContent = `HP ${h.hp | 0}/${h.maxHp | 0}`;
+        heroMP.textContent = `MP ${h.mp | 0}/${h.maxMp | 0}`;
+        heroLVL.textContent = 'Lvl ' + h.levelStacks;
+        const info = abilityInfo[h.heroClass] || {};
+        ab1.title = info[1] || '';
+        ab2.title = info[2] || '';
+        ab3.title = info[3] || '';
+      }
       ab1.onclick = () => tryCast(1); ab2.onclick = () => tryCast(2); ab3.onclick = () => tryCast(3);
       function spawnHero(owner, x, y, cls = null) {
         const h = new Unit(x, y, owner, 'soldier'); h.isHero = true; h.maxHp = 420; h.hp = 420; h.maxMp = 160; h.mp = 120; h.dps = 50; h.attackRange = 40; h.vision = 560; h.inventory = []; h.levelStacks = 0; h.regen = 1.2; h.mpRegen = 0.8;
@@ -86,7 +114,7 @@ let simTime = 0;
         for (let i = 0; i < cap; i++) {
           const slot = document.createElement('div'); slot.className = 'invSlot';
           if (arr[i]) {
-            const it = arr[i]; const names = { scroll_hp: 'Свиток HP', scroll_dps: 'Свиток DPS', ring_atk: 'Кольцо атаки', boots: 'Сапоги', amulet: 'Амулет', orb: 'Орб маны' };
+            const it = arr[i]; const names = { scroll_hp: 'Свиток HP', scroll_dps: 'Свиток DPS', ring_atk: 'Кольцо маны', boots: 'Сапоги', amulet: 'Амулет', orb: 'Орб маны' };
             slot.textContent = names[it] || it;
             slot.title = 'ЛКМ/ПКМ — использовать';
             slot.onclick = (e) => { applyItem(hero, it); hero.inventory.splice(i, 1); renderInventory(hero); };
@@ -95,7 +123,23 @@ let simTime = 0;
           invGrid.appendChild(slot);
         }
       }
-      function applyItem(hero, itemKind) { if (itemKind === 'scroll_hp') { hero.maxHp += 80; hero.hp = Math.min(hero.maxHp, hero.hp + 120); } if (itemKind === 'scroll_dps') { hero.dps = (hero.dps || 40) + 10; } if (itemKind === 'ring_atk') { hero.dps += 6; } if (itemKind === 'boots') { hero.baseSpeed += 20; hero.speed += 20; } if (itemKind === 'amulet') { hero.maxHp += 120; hero.hp += 120; } if (itemKind === 'orb') { hero.maxMp += 60; hero.mp += 60; } if (hero.owner === 0) setHeroUI(hero); }
+      function applyItem(hero, itemKind) {
+        if (itemKind === 'scroll_hp') {
+          hero.maxHp += 80; hero.hp = Math.min(hero.maxHp, hero.hp + 120);
+        } else if (itemKind === 'scroll_dps') {
+          hero.dps += 10;
+          setTimeout(() => { hero.dps -= 10; }, 20000);
+        } else if (itemKind === 'ring_atk') {
+          hero.maxMp += 40; hero.mp += 40;
+        } else if (itemKind === 'boots') {
+          hero.baseSpeed += 20; hero.speed += 20;
+        } else if (itemKind === 'amulet') {
+          hero.maxHp += 120; hero.hp += 120;
+        } else if (itemKind === 'orb') {
+          hero.maxMp += 60; hero.mp += 60;
+        }
+        if (hero.owner === 0) setHeroUI(hero);
+      }
       function tryCast(slot) {
         const h = players[0].hero; if (!h || h.dead) return;
         if (slot === 1 && h.cd1 <= 0) {


### PR DESCRIPTION
## Summary
- Prevent units from getting stuck on trees and water by sliding around blockers
- Add detailed ability descriptions with mana costs and effects for all hero classes
- Rework items: ring grants mana and DPS scroll gives a 20s damage boost
- Teach AI armies to farm neutral camps earlier for faster development

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cc4cac32c8327945e69d466222a76