### PR TITLE
Fix menu flow and redesign overlays

### DIFF
--- a/docs/MiniRTS_Ultra_FULL_NoSprites_v12_1755074840.html
+++ b/docs/MiniRTS_Ultra_FULL_NoSprites_v12_1755074840.html
@@ -48,7 +48,7 @@
   <div class="panel" id="statsPanel">—</div>
   <div id="buildTip">Режим строительства: клик по земле, ПКМ — отмена</div>
 
-  <div id="heroSelect" style="display:none">
+  <div id="heroSelect" class="overlay">
     <div class="card">
       <h3>Выберите героя</h3>
       <div class="heroChoice">
@@ -59,7 +59,7 @@
     </div>
   </div>
 
-  <div id="menu">
+  <div id="menu" class="overlay">
     <div class="card">
       <h2>MiniRTS Ultra — FULL v12 (без спрайтов)</h2>
       <p>Полный функционал: ИИ, добыча рис/воды, строительство, туман/миником, герои с умениями, лут с нейтралов,
@@ -75,7 +75,7 @@
     </div>
   </div>
 
-  <div id="resultMenu">
+  <div id="resultMenu" class="overlay">
     <div class="card">
       <h2 id="resultText">Победа!</h2>
       <div style="display:flex;justify-content:center;margin-top:12px">

--- a/src/ui.js
+++ b/src/ui.js
@@ -15,18 +15,22 @@ globalThis.fogEnabled = true;
 
 btnStart.onclick = async () => {
   resultMenu.style.display = 'none';
+  menu.style.display = 'none';
   await globalThis.resetGame();
   globalThis.paused = false;
-  menu.style.display = 'none';
 };
 btnRestart.onclick = async () => {
   resultMenu.style.display = 'none';
+  menu.style.display = 'none';
   await globalThis.resetGame();
   globalThis.paused = false;
-  menu.style.display = 'none';
 };
 btnMute.onclick = () => { globalThis.muted = !globalThis.muted; btnMute.textContent = globalThis.muted ? 'Звук: выкл' : 'Звук: вкл'; };
-btnPause.onclick = () => { globalThis.paused = !globalThis.paused; menu.style.display = globalThis.paused ? 'flex' : 'none'; };
+btnPause.onclick = () => {
+  globalThis.paused = !globalThis.paused;
+  if (globalThis.paused) document.getElementById('heroSelect').style.display = 'none';
+  menu.style.display = globalThis.paused ? 'flex' : 'none';
+};
 btnFog.onclick = () => { globalThis.fogEnabled = !globalThis.fogEnabled; btnFog.textContent = globalThis.fogEnabled ? 'No Fog' : 'Fog'; };
 
 btnResultRestart.onclick = () => {
@@ -39,5 +43,7 @@ globalThis.showResultMenu = (msg) => {
   globalThis.paused = true;
   if (globalThis.setHeroUI) globalThis.setHeroUI(null);
   resultText.textContent = msg;
+  menu.style.display = 'none';
+  document.getElementById('heroSelect').style.display = 'none';
   resultMenu.style.display = 'flex';
 };

--- a/style.css
+++ b/style.css
@@ -174,14 +174,28 @@
       z-index: 85
     }
 
-    #heroSelect {
+    .overlay {
       position: fixed;
       inset: 0;
-      display: flex;
+      display: none;
       align-items: center;
       justify-content: center;
-      background: rgba(0, 0, 0, .65);
-      z-index: 95
+      background: radial-gradient(1200px 600px at 50% 0%, rgba(60, 90, 130, .25), rgba(0, 0, 0, .85));
+    }
+
+    .card {
+      background: rgba(0, 0, 0, .6);
+      padding: 22px 26px;
+      border-radius: 16px;
+      border: 1px solid rgba(255, 255, 255, .1);
+    }
+
+    #heroSelect {
+      z-index: 100;
+    }
+    #heroSelect .card {
+      text-align: center;
+      max-width: 600px;
     }
 
     .heroChoice {
@@ -199,38 +213,19 @@
     }
 
     #menu {
-      position: fixed;
-      inset: 0;
       display: flex;
-      align-items: center;
-      justify-content: center;
-      background: radial-gradient(1200px 600px at 50% 0%, rgba(60, 90, 130, .25), rgba(0, 0, 0, .85));
-      z-index: 100
+      z-index: 100;
     }
 
     #menu .card {
-      background: rgba(0, 0, 0, .6);
-      padding: 22px 26px;
-      border-radius: 16px;
-      border: 1px solid rgba(255, 255, 255, .1);
-      max-width: 900px
+      max-width: 900px;
     }
 
     #resultMenu {
-      position: fixed;
-      inset: 0;
-      display: none;
-      align-items: center;
-      justify-content: center;
-      background: radial-gradient(1200px 600px at 50% 0%, rgba(60, 90, 130, .25), rgba(0, 0, 0, .85));
-      z-index: 110
+      z-index: 110;
     }
 
     #resultMenu .card {
-      background: rgba(0, 0, 0, .6);
-      padding: 22px 26px;
-      border-radius: 16px;
-      border: 1px solid rgba(255, 255, 255, .1);
       max-width: 600px;
-      text-align: center
+      text-align: center;
     }


### PR DESCRIPTION
## Summary
- Prevent main menu from overlapping hero selection or result screens
- Add reusable overlay/card styles and apply them across menus

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ce1b54c888327aad384704ccedcd9