### PR TITLE
Improve worker behavior, selection, and UI

### DIFF
--- a/docs/MiniRTS_Ultra_FULL_NoSprites_v12_1755074840.html
+++ b/docs/MiniRTS_Ultra_FULL_NoSprites_v12_1755074840.html
@@ -16,6 +16,7 @@
     <span class="pill">🍚 Рис: <span id="resRice">0</span></span>
     <span class="pill">💧 Вода: <span id="resWater">0</span></span>
     <span class="pill">👥 Поп: <span id="pop">0</span>/20</span>
+    <span class="pill">😴 Безд.: <span id="idleWorkers">0</span></span>
     <button id="btnFog">No Fog</button>
     <button id="btnPause">Меню</button>
   </div>

--- a/src/entities.js
+++ b/src/entities.js
@@ -50,8 +50,8 @@ export class Unit extends Entity {
     super(x, y, owner);
     this.type = type;
     this.radius = 12;
-    this.speed = 190;
-    this.baseSpeed = 190;
+    this.speed = 160;
+    this.baseSpeed = 160;
     this.destX = x;
     this.destY = y;
     this.attackRange = 28;
@@ -83,6 +83,8 @@ export class Unit extends Entity {
     this.regen = 0.25;
     this.auraTimer = 0;
     this.buildTargetId = null;
+    this.nodeId = null;
+    this.alertTimer = 0;
   }
   setDest(x, y) {
     this.destX = x;
@@ -101,13 +103,20 @@ export class Unit extends Entity {
     if (this.role !== 'rice' && this.role !== 'water') return;
     const P = globalThis.players[this.owner];
     const HQ = P.structures.find(s => s.kind === 'hq');
-    if (!HQ) { this.state = 'idle'; return; }
+    if (!HQ) { this.state = 'idle'; this.nodeId = null; this.alertTimer = 2.5; return; }
     const node = (this.role === 'rice' ? nearestNode('rice', P) : nearestNode('water', P));
-    if (!node) { this.state = 'idle'; return; }
+    if (!node) { this.state = 'idle'; this.nodeId = null; this.alertTimer = 2.5; return; }
+    if (this.nodeId !== node.id && this.state !== 'to_hq') {
+      this.state = 'to_node';
+      this.destX = node.x + globalThis.rand(-24, 24);
+      this.destY = node.y + globalThis.rand(-24, 24);
+      this.nodeId = node.id;
+    }
     if (this.state === 'idle') {
       this.state = 'to_node';
       this.destX = node.x + globalThis.rand(-24, 24);
       this.destY = node.y + globalThis.rand(-24, 24);
+      this.nodeId = node.id;
     }
     if (this.state === 'to_node') {
       const dx = this.destX - this.x, dy = this.destY - this.y, d = Math.hypot(dx, dy);
@@ -143,6 +152,7 @@ export class Unit extends Entity {
         this.state = 'to_node';
         this.destX = node.x + globalThis.rand(-24, 24);
         this.destY = node.y + globalThis.rand(-24, 24);
+        this.nodeId = node.id;
       }
     }
   }
@@ -198,6 +208,7 @@ export class Unit extends Entity {
     this.cd3 = Math.max(0, this.cd3 - dt);
     if (this.speedBuff > 0) { this.speedBuff = Math.max(0, this.speedBuff - dt); }
     if (this.slow > 0) { this.slow = Math.max(0, this.slow - dt); }
+    if (this.alertTimer > 0) { this.alertTimer = Math.max(0, this.alertTimer - dt); }
     if (this.summonTimer > 0) { this.summonTimer -= dt; if (this.summonTimer <= 0) { this.dead = true; } }
     if (this.state === 'build') {
       const target = getById(this.buildTargetId);
@@ -235,6 +246,11 @@ export class Unit extends Entity {
     const spr = this.isHero ? 'hero' : (this.type === 'archer' ? 'archer' : (this.type === 'mage' ? 'mage' : 'soldier'));
     globalThis.drawSprite(spr, s.x, s.y, globalThis.world.zoom * 1.25, { o: col });
     globalThis.drawHp(s.x, s.y - 18 * globalThis.world.zoom, this.hp / this.maxHp);
+    if (this.alertTimer > 0) {
+      globalThis.ctx.fillStyle = '#ffd27a';
+      globalThis.ctx.font = `${18 * globalThis.world.zoom}px system-ui`;
+      globalThis.ctx.fillText('!', s.x - 5 * globalThis.world.zoom, s.y - 24 * globalThis.world.zoom);
+    }
     if (this.auraTimer > 0) {
       globalThis.ctx.strokeStyle = 'rgba(255,215,0,0.5)';
       globalThis.ctx.beginPath();

--- a/src/main.js
+++ b/src/main.js
@@ -80,9 +80,14 @@ function drawWeather(dt) {
         { name: 'AI‑2', color: '#ffd27a', res: { rice: 220, water: 100 }, units: [], structures: [], hero: null, ai: true, aiPlan: null }
       ];
       const riceNodes = [], waterNodes = [];
-      const resUI = { rice: document.getElementById('resRice'), water: document.getElementById('resWater'), pop: document.getElementById('pop') };
+      const resUI = { rice: document.getElementById('resRice'), water: document.getElementById('resWater'), pop: document.getElementById('pop'), idle: document.getElementById('idleWorkers') };
       const POP_CAP = 20;
-      function updateRes() { resUI.rice.textContent = players[0].res.rice | 0; resUI.water.textContent = players[0].res.water | 0; resUI.pop.textContent = players[0].units.filter(u => !u.dead && !u.isHero).length; }
+      function updateRes() {
+        resUI.rice.textContent = players[0].res.rice | 0;
+        resUI.water.textContent = players[0].res.water | 0;
+        resUI.pop.textContent = players[0].units.filter(u => !u.dead && !u.isHero).length;
+        resUI.idle.textContent = players[0].units.filter(u => u.type === 'worker' && u.state === 'idle').length;
+      }
 
       /* ==== Training & buildings ==== */
       const COSTS = { barracks: { rice: 180, water: 70 }, mBarracks: { rice: 220, water: 110 }, well: { rice: 140, water: 0 }, range: { rice: 160, water: 80 }, altar: { rice: 200, water: 140 } };
@@ -121,7 +126,7 @@ function drawWeather(dt) {
         }
       };
       function setHeroUI(h) {
-        if (!h) { heroPanel.style.display = 'none'; invPanel.style.display = 'none'; return; }
+        if (!h || !h.selected) { heroPanel.style.display = 'none'; invPanel.style.display = 'none'; return; }
         heroPanel.style.display = 'block'; invPanel.style.display = 'block';
         heroName.textContent = h.heroName + ' (' + h.heroClass + ')';
         heroHP.textContent = `HP ${h.hp | 0}/${h.maxHp | 0}`;
@@ -234,8 +239,12 @@ function drawWeather(dt) {
 
       /* ==== Input & selection ==== */
       const buildTip = document.getElementById('buildTip');
-      const input = { x: 0, y: 0, wx: 0, wy: 0, keys: {}, buildMode: null, lastClickT: 0, lastClickType: null };
-      cvs.addEventListener('mousemove', e => { input.x = e.offsetX; input.y = e.offsetY; const w = screenToWorld(input.x, input.y); input.wx = w.x; input.wy = w.y; });
+      const input = { x: 0, y: 0, wx: 0, wy: 0, keys: {}, buildMode: null, lastClickT: 0, lastClickType: null, rdown: false, rStartX: 0, rStartY: 0, rStartWX: 0, rStartWY: 0, selX: 0, selY: 0, selWX: 0, selWY: 0 };
+      cvs.addEventListener('mousemove', e => {
+        input.x = e.offsetX; input.y = e.offsetY;
+        const w = screenToWorld(input.x, input.y); input.wx = w.x; input.wy = w.y;
+        if (input.rdown) { input.selX = e.offsetX; input.selY = e.offsetY; input.selWX = w.x; input.selWY = w.y; }
+      });
       cvs.addEventListener('contextmenu', e => { e.preventDefault(); if (input.buildMode) { input.buildMode = null; buildTip.style.display = 'none'; } });
       window.addEventListener('keydown', e => { const k = e.key.toLowerCase(); input.keys[k] = true; if (k === 'f') globalThis.fogEnabled = !globalThis.fogEnabled; if (k === '1') tryCast(1); if (k === '2') tryCast(2); if (k === '3') tryCast(3); if (k === 'u') { const h = players[0].hero; if (h && h.inventory.length) { const it = h.inventory.shift(); applyItem(h, it); renderInventory(h); } } if (k === 'r') { resumeWorkers(players[0]); } });
       window.addEventListener('keyup', e => { input.keys[e.key.toLowerCase()] = false; });
@@ -264,19 +273,49 @@ function drawWeather(dt) {
           }
           updatePanels();
         } else if (e.button === 2) {
-          if (input.buildMode) { input.buildMode = null; buildTip.style.display = 'none'; return; }
-          const sel = players[0].units.filter(u => u.selected && !u.dead);
-          const tgt = entityAt(input.wx, input.wy);
-          if (sel.length === 0 && tgt && tgt.owner === 0) {
-            unselectAll(); tgt.selected = true; updatePanels(); return;
-          }
-          if (sel.length) {
-            if (tgt instanceof Structure && tgt.isGhost && sel.some(u => u.type === 'worker')) {
-              sel.filter(u => u.type === 'worker').forEach(w => { w.state = 'build'; w.buildTargetId = tgt.id; });
-            } else if (tgt instanceof ResourceNode && sel.some(u => u.type === 'worker')) {
-              sel.filter(u => u.type === 'worker').forEach(w => { w.role = tgt.type; w.state = 'idle'; });
-            } else if (tgt && tgt.owner !== 0) { sel.forEach(u => u.setTarget(tgt)); }
-            else { sel.forEach((u, i) => u.setDest(input.wx + i * 12, input.wy)); }
+          input.rdown = true;
+          input.rStartX = e.offsetX; input.rStartY = e.offsetY;
+          input.rStartWX = input.wx; input.rStartWY = input.wy;
+          input.selX = e.offsetX; input.selY = e.offsetY;
+          input.selWX = input.wx; input.selWY = input.wy;
+        }
+      });
+
+      cvs.addEventListener('mouseup', e => {
+        if (e.button === 2) {
+          const dx = e.offsetX - input.rStartX;
+          const dy = e.offsetY - input.rStartY;
+          const dist = Math.hypot(dx, dy);
+          input.rdown = false;
+          if (input.buildMode) { input.buildMode = null; buildTip.style.display = 'none'; if (dist <= 4) return; }
+          if (dist > 4) {
+            const x1 = Math.min(input.rStartWX, input.selWX), y1 = Math.min(input.rStartWY, input.selWY);
+            const x2 = Math.max(input.rStartWX, input.selWX), y2 = Math.max(input.rStartWY, input.selWY);
+            if (!e.shiftKey) unselectAll();
+            for (const u of players[0].units) {
+              if (u.dead) continue;
+              if (u.x >= x1 && u.x <= x2 && u.y >= y1 && u.y <= y2) u.selected = true;
+            }
+            for (const s of players[0].structures) {
+              if (s.dead || s.isGhost) continue;
+              if (s.x >= x1 && s.x <= x2 && s.y >= y1 && s.y <= y2) s.selected = true;
+            }
+            updatePanels();
+          } else {
+            if (input.buildMode) { input.buildMode = null; buildTip.style.display = 'none'; return; }
+            const sel = players[0].units.filter(u => u.selected && !u.dead);
+            const tgt = entityAt(input.wx, input.wy);
+            if (sel.length === 0 && tgt && tgt.owner === 0) {
+              unselectAll(); tgt.selected = true; updatePanels(); return;
+            }
+            if (sel.length) {
+              if (tgt instanceof Structure && tgt.isGhost && sel.some(u => u.type === 'worker')) {
+                sel.filter(u => u.type === 'worker').forEach(w => { w.state = 'build'; w.buildTargetId = tgt.id; });
+              } else if (tgt instanceof ResourceNode && sel.some(u => u.type === 'worker')) {
+                sel.filter(u => u.type === 'worker').forEach(w => { w.role = tgt.type; w.state = 'idle'; });
+              } else if (tgt && tgt.owner !== 0) { sel.forEach(u => u.setTarget(tgt)); }
+              else { sel.forEach((u, i) => u.setDest(input.wx + i * 12, input.wy)); }
+            }
           }
         }
       });
@@ -431,6 +470,14 @@ globalThis.drawHp = drawHp;
         for (const e of drawables) { if (e.draw) e.draw(); }
         drawWeather(dt);
         drawFog();
+        if (input.rdown) {
+          const x = Math.min(input.rStartX, input.selX);
+          const y = Math.min(input.rStartY, input.selY);
+          const w = Math.abs(input.selX - input.rStartX);
+          const h = Math.abs(input.selY - input.rStartY);
+          ctx.strokeStyle = '#7ac8ff';
+          ctx.strokeRect(x, y, w, h);
+        }
         // cursor
         ctx.strokeStyle = 'rgba(255,255,255,0.5)'; ctx.beginPath(); const c = 8; ctx.moveTo(input.x - c, input.y); ctx.lineTo(input.x + c, input.y); ctx.moveTo(input.x, input.y - c); ctx.lineTo(input.x, input.y + c); ctx.stroke();
         drawMinimap();

--- a/src/ui.js
+++ b/src/ui.js
@@ -8,6 +8,9 @@ const btnFog = document.getElementById('btnFog');
 const resultMenu = document.getElementById('resultMenu');
 const resultText = document.getElementById('resultText');
 const btnResultRestart = document.getElementById('btnResultRestart');
+const idleWorkersEl = document.getElementById('idleWorkers');
+
+globalThis.idleWorkersEl = idleWorkersEl;
 
 globalThis.paused = true;
 globalThis.muted = false;


### PR DESCRIPTION
## Summary
- Show alert icon and idle state when workers lose HQ or resource node, and auto-redirect to new nodes
- Display idle worker count in UI and slow down unit movement
- Allow right-button drag box selection and hide hero abilities panel when hero not selected

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cea235fe883279f83ad48232b89c1