### PR TITLE
Improve worker AI, UI, and selection mechanics

### DIFF
--- a/src/entities.js
+++ b/src/entities.js
@@ -50,8 +50,8 @@ export class Unit extends Entity {
     super(x, y, owner);
     this.type = type;
     this.radius = 12;
-    this.speed = 190;
-    this.baseSpeed = 190;
+    this.speed = 150;
+    this.baseSpeed = 150;
     this.destX = x;
     this.destY = y;
     this.attackRange = 28;
@@ -83,6 +83,8 @@ export class Unit extends Entity {
     this.regen = 0.25;
     this.auraTimer = 0;
     this.buildTargetId = null;
+    this.nodeId = null;
+    this.noticeTimer = 0;
   }
   setDest(x, y) {
     this.destX = x;
@@ -101,11 +103,27 @@ export class Unit extends Entity {
     if (this.role !== 'rice' && this.role !== 'water') return;
     const P = globalThis.players[this.owner];
     const HQ = P.structures.find(s => s.kind === 'hq');
-    if (!HQ) { this.state = 'idle'; return; }
+    if (!HQ) {
+      this.state = 'idle';
+      this.nodeId = null;
+      this.noticeTimer = 2.0;
+      return;
+    }
     const node = (this.role === 'rice' ? nearestNode('rice', P) : nearestNode('water', P));
-    if (!node) { this.state = 'idle'; return; }
-    if (this.state === 'idle') {
+    if (!node) {
+      this.state = 'idle';
+      this.nodeId = null;
+      this.noticeTimer = 2.0;
+      return;
+    }
+    if (this.nodeId !== node.id && this.state !== 'to_hq') {
+      this.nodeId = node.id;
       this.state = 'to_node';
+      this.destX = node.x + globalThis.rand(-24, 24);
+      this.destY = node.y + globalThis.rand(-24, 24);
+    } else if (this.state === 'idle') {
+      this.state = 'to_node';
+      this.nodeId = node.id;
       this.destX = node.x + globalThis.rand(-24, 24);
       this.destY = node.y + globalThis.rand(-24, 24);
     }
@@ -141,6 +159,7 @@ export class Unit extends Entity {
           this.carry = 0;
         }
         this.state = 'to_node';
+        this.nodeId = node.id;
         this.destX = node.x + globalThis.rand(-24, 24);
         this.destY = node.y + globalThis.rand(-24, 24);
       }
@@ -192,6 +211,7 @@ export class Unit extends Entity {
     if (this.mp < this.maxMp) {
       this.mp = Math.min(this.maxMp, this.mp + this.mpRegen * dt * 60);
     }
+    if (this.noticeTimer > 0) { this.noticeTimer = Math.max(0, this.noticeTimer - dt); }
     if (this.auraTimer > 0) { this.auraTimer = Math.max(0, this.auraTimer - dt); }
     this.cd1 = Math.max(0, this.cd1 - dt);
     this.cd2 = Math.max(0, this.cd2 - dt);
@@ -246,6 +266,11 @@ export class Unit extends Entity {
       globalThis.ctx.beginPath();
       globalThis.ctx.arc(s.x, s.y, 14 * globalThis.world.zoom, 0, 6.283);
       globalThis.ctx.stroke();
+    }
+    if (this.noticeTimer > 0) {
+      globalThis.ctx.fillStyle = '#ffd27a';
+      globalThis.ctx.font = `${14 * globalThis.world.zoom}px system-ui`;
+      globalThis.ctx.fillText('!', s.x - 4 * globalThis.world.zoom, s.y - 24 * globalThis.world.zoom);
     }
     if (this.selected) {
       globalThis.ctx.strokeStyle = '#7ac8ff';
@@ -379,7 +404,7 @@ export class NeutralCreep extends Entity {
     this.vision = 280 + 40 * (this.tier - 1);
     this.awarded = false;
     this.regen = 0.2;
-    this.baseSpeed = 80;
+    this.baseSpeed = 60;
   }
   damage(n, killerOwner = null) {
     if (this.kind === 'gnome' && Math.random() < 0.25) n *= 0.5;

--- a/src/main.js
+++ b/src/main.js
@@ -80,9 +80,9 @@ function drawWeather(dt) {
         { name: 'AI‑2', color: '#ffd27a', res: { rice: 220, water: 100 }, units: [], structures: [], hero: null, ai: true, aiPlan: null }
       ];
       const riceNodes = [], waterNodes = [];
-      const resUI = { rice: document.getElementById('resRice'), water: document.getElementById('resWater'), pop: document.getElementById('pop') };
+      const resUI = { rice: document.getElementById('resRice'), water: document.getElementById('resWater'), pop: document.getElementById('pop'), idle: document.getElementById('idleWorkers') };
       const POP_CAP = 20;
-      function updateRes() { resUI.rice.textContent = players[0].res.rice | 0; resUI.water.textContent = players[0].res.water | 0; resUI.pop.textContent = players[0].units.filter(u => !u.dead && !u.isHero).length; }
+      function updateRes() { resUI.rice.textContent = players[0].res.rice | 0; resUI.water.textContent = players[0].res.water | 0; resUI.pop.textContent = players[0].units.filter(u => !u.dead && !u.isHero).length; resUI.idle.textContent = players[0].units.filter(u => !u.dead && u.type === 'worker' && u.state === 'idle').length; }
 
       /* ==== Training & buildings ==== */
       const COSTS = { barracks: { rice: 180, water: 70 }, mBarracks: { rice: 220, water: 110 }, well: { rice: 140, water: 0 }, range: { rice: 160, water: 80 }, altar: { rice: 200, water: 140 } };
@@ -121,7 +121,7 @@ function drawWeather(dt) {
         }
       };
       function setHeroUI(h) {
-        if (!h) { heroPanel.style.display = 'none'; invPanel.style.display = 'none'; return; }
+        if (!h || !h.selected) { heroPanel.style.display = 'none'; invPanel.style.display = 'none'; return; }
         heroPanel.style.display = 'block'; invPanel.style.display = 'block';
         heroName.textContent = h.heroName + ' (' + h.heroClass + ')';
         heroHP.textContent = `HP ${h.hp | 0}/${h.maxHp | 0}`;
@@ -234,7 +234,7 @@ function drawWeather(dt) {
 
       /* ==== Input & selection ==== */
       const buildTip = document.getElementById('buildTip');
-      const input = { x: 0, y: 0, wx: 0, wy: 0, keys: {}, buildMode: null, lastClickT: 0, lastClickType: null };
+      const input = { x: 0, y: 0, wx: 0, wy: 0, keys: {}, buildMode: null, lastClickT: 0, lastClickType: null, rDrag: false, dragSX: 0, dragSY: 0, dragWX: 0, dragWY: 0 };
       cvs.addEventListener('mousemove', e => { input.x = e.offsetX; input.y = e.offsetY; const w = screenToWorld(input.x, input.y); input.wx = w.x; input.wy = w.y; });
       cvs.addEventListener('contextmenu', e => { e.preventDefault(); if (input.buildMode) { input.buildMode = null; buildTip.style.display = 'none'; } });
       window.addEventListener('keydown', e => { const k = e.key.toLowerCase(); input.keys[k] = true; if (k === 'f') globalThis.fogEnabled = !globalThis.fogEnabled; if (k === '1') tryCast(1); if (k === '2') tryCast(2); if (k === '3') tryCast(3); if (k === 'u') { const h = players[0].hero; if (h && h.inventory.length) { const it = h.inventory.shift(); applyItem(h, it); renderInventory(h); } } if (k === 'r') { resumeWorkers(players[0]); } });
@@ -265,19 +265,46 @@ function drawWeather(dt) {
           updatePanels();
         } else if (e.button === 2) {
           if (input.buildMode) { input.buildMode = null; buildTip.style.display = 'none'; return; }
-          const sel = players[0].units.filter(u => u.selected && !u.dead);
-          const tgt = entityAt(input.wx, input.wy);
-          if (sel.length === 0 && tgt && tgt.owner === 0) {
-            unselectAll(); tgt.selected = true; updatePanels(); return;
+          input.rDrag = true;
+          input.dragSX = e.offsetX;
+          input.dragSY = e.offsetY;
+          input.dragWX = input.wx;
+          input.dragWY = input.wy;
+        }
+      });
+
+      window.addEventListener('mouseup', e => {
+        if (e.button === 2) {
+          if (!input.rDrag) return;
+          const dx = Math.abs(input.x - input.dragSX);
+          const dy = Math.abs(input.y - input.dragSY);
+          if (dx > 4 && dy > 4) {
+            const x1 = Math.min(input.dragWX, input.wx);
+            const y1 = Math.min(input.dragWY, input.wy);
+            const x2 = Math.max(input.dragWX, input.wx);
+            const y2 = Math.max(input.dragWY, input.wy);
+            if (!e.shiftKey) unselectAll();
+            for (const u of players[0].units) {
+              if (u.dead) continue;
+              if (u.x >= x1 && u.x <= x2 && u.y >= y1 && u.y <= y2) u.selected = true;
+            }
+            updatePanels();
+          } else {
+            if (input.buildMode) { input.buildMode = null; buildTip.style.display = 'none'; }
+            const sel = players[0].units.filter(u => u.selected && !u.dead);
+            const tgt = entityAt(input.wx, input.wy);
+            if (sel.length === 0 && tgt && tgt.owner === 0) {
+              unselectAll(); tgt.selected = true; updatePanels();
+            } else if (sel.length) {
+              if (tgt instanceof Structure && tgt.isGhost && sel.some(u => u.type === 'worker')) {
+                sel.filter(u => u.type === 'worker').forEach(w => { w.state = 'build'; w.buildTargetId = tgt.id; });
+              } else if (tgt instanceof ResourceNode && sel.some(u => u.type === 'worker')) {
+                sel.filter(u => u.type === 'worker').forEach(w => { w.role = tgt.type; w.state = 'idle'; });
+              } else if (tgt && tgt.owner !== 0) { sel.forEach(u => u.setTarget(tgt)); }
+              else { sel.forEach((u, i) => u.setDest(input.wx + i * 12, input.wy)); }
+            }
           }
-          if (sel.length) {
-            if (tgt instanceof Structure && tgt.isGhost && sel.some(u => u.type === 'worker')) {
-              sel.filter(u => u.type === 'worker').forEach(w => { w.state = 'build'; w.buildTargetId = tgt.id; });
-            } else if (tgt instanceof ResourceNode && sel.some(u => u.type === 'worker')) {
-              sel.filter(u => u.type === 'worker').forEach(w => { w.role = tgt.type; w.state = 'idle'; });
-            } else if (tgt && tgt.owner !== 0) { sel.forEach(u => u.setTarget(tgt)); }
-            else { sel.forEach((u, i) => u.setDest(input.wx + i * 12, input.wy)); }
-          }
+          input.rDrag = false;
         }
       });
 
@@ -431,6 +458,14 @@ globalThis.drawHp = drawHp;
         for (const e of drawables) { if (e.draw) e.draw(); }
         drawWeather(dt);
         drawFog();
+        if (input.rDrag) {
+          ctx.strokeStyle = '#7ac8ff';
+          const sx = Math.min(input.dragSX, input.x);
+          const sy = Math.min(input.dragSY, input.y);
+          const w = Math.abs(input.dragSX - input.x);
+          const h = Math.abs(input.dragSY - input.y);
+          ctx.strokeRect(sx, sy, w, h);
+        }
         // cursor
         ctx.strokeStyle = 'rgba(255,255,255,0.5)'; ctx.beginPath(); const c = 8; ctx.moveTo(input.x - c, input.y); ctx.lineTo(input.x + c, input.y); ctx.moveTo(input.x, input.y - c); ctx.lineTo(input.x, input.y + c); ctx.stroke();
         drawMinimap();

--- a/src/ui.js
+++ b/src/ui.js
@@ -9,6 +9,12 @@ const resultMenu = document.getElementById('resultMenu');
 const resultText = document.getElementById('resultText');
 const btnResultRestart = document.getElementById('btnResultRestart');
 
+const uiBar = document.getElementById('ui');
+const idleWrap = document.createElement('span');
+idleWrap.className = 'pill';
+idleWrap.innerHTML = '⏳ Безд.: <span id="idleWorkers">0</span>';
+uiBar.insertBefore(idleWrap, btnFog);
+
 globalThis.paused = true;
 globalThis.muted = false;
 globalThis.fogEnabled = true;


### PR DESCRIPTION
## Summary
- Reassign workers when resource nodes or HQ are missing and show warning icon
- Track idle worker count in UI and slow overall unit movement
- Support box-select with right-click drag and hide hero abilities when hero unselected

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cea235fe883279f83ad48232b89c1