### PR TITLE
Improve worker logic and selection controls

### DIFF
--- a/docs/MiniRTS_Ultra_FULL_NoSprites_v12_1755074840.html
+++ b/docs/MiniRTS_Ultra_FULL_NoSprites_v12_1755074840.html
@@ -16,6 +16,7 @@
     <span class="pill">🍚 Рис: <span id="resRice">0</span></span>
     <span class="pill">💧 Вода: <span id="resWater">0</span></span>
     <span class="pill">👥 Поп: <span id="pop">0</span>/20</span>
+    <span class="pill">😴 Idle: <span id="idleWorkers">0</span></span>
     <button id="btnFog">No Fog</button>
     <button id="btnPause">Меню</button>
   </div>

--- a/src/entities.js
+++ b/src/entities.js
@@ -50,8 +50,8 @@ export class Unit extends Entity {
     super(x, y, owner);
     this.type = type;
     this.radius = 12;
-    this.speed = 190;
-    this.baseSpeed = 190;
+    this.speed = 150;
+    this.baseSpeed = 150;
     this.destX = x;
     this.destY = y;
     this.attackRange = 28;
@@ -83,6 +83,8 @@ export class Unit extends Entity {
     this.regen = 0.25;
     this.auraTimer = 0;
     this.buildTargetId = null;
+    this.noteTimer = 0;
+    this.nodeId = null;
   }
   setDest(x, y) {
     this.destX = x;
@@ -101,9 +103,15 @@ export class Unit extends Entity {
     if (this.role !== 'rice' && this.role !== 'water') return;
     const P = globalThis.players[this.owner];
     const HQ = P.structures.find(s => s.kind === 'hq');
-    if (!HQ) { this.state = 'idle'; return; }
+    if (!HQ) { this.state = 'idle'; this.noteTimer = 2; return; }
     const node = (this.role === 'rice' ? nearestNode('rice', P) : nearestNode('water', P));
-    if (!node) { this.state = 'idle'; return; }
+    if (!node) { this.state = 'idle'; this.noteTimer = 2; this.nodeId = null; return; }
+    if (this.nodeId !== node.id && this.state !== 'to_hq') {
+      this.nodeId = node.id;
+      this.state = 'to_node';
+      this.destX = node.x + globalThis.rand(-24, 24);
+      this.destY = node.y + globalThis.rand(-24, 24);
+    }
     if (this.state === 'idle') {
       this.state = 'to_node';
       this.destX = node.x + globalThis.rand(-24, 24);
@@ -199,6 +207,7 @@ export class Unit extends Entity {
     if (this.speedBuff > 0) { this.speedBuff = Math.max(0, this.speedBuff - dt); }
     if (this.slow > 0) { this.slow = Math.max(0, this.slow - dt); }
     if (this.summonTimer > 0) { this.summonTimer -= dt; if (this.summonTimer <= 0) { this.dead = true; } }
+    if (this.noteTimer > 0) { this.noteTimer = Math.max(0, this.noteTimer - dt); }
     if (this.state === 'build') {
       const target = getById(this.buildTargetId);
       if (!target || !target.isGhost) { this.state = 'idle'; this.buildTargetId = null; }
@@ -252,6 +261,11 @@ export class Unit extends Entity {
       globalThis.ctx.beginPath();
       globalThis.ctx.arc(s.x, s.y, 16 * globalThis.world.zoom, 0, 6.283);
       globalThis.ctx.stroke();
+    }
+    if (this.noteTimer > 0 && this.type === 'worker') {
+      globalThis.ctx.fillStyle = '#ffd27a';
+      globalThis.ctx.font = `${12 * globalThis.world.zoom}px sans-serif`;
+      globalThis.ctx.fillText('!', s.x - 3 * globalThis.world.zoom, s.y - 20 * globalThis.world.zoom);
     }
   }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -80,9 +80,14 @@ function drawWeather(dt) {
         { name: 'AI‑2', color: '#ffd27a', res: { rice: 220, water: 100 }, units: [], structures: [], hero: null, ai: true, aiPlan: null }
       ];
       const riceNodes = [], waterNodes = [];
-      const resUI = { rice: document.getElementById('resRice'), water: document.getElementById('resWater'), pop: document.getElementById('pop') };
+      const resUI = { rice: document.getElementById('resRice'), water: document.getElementById('resWater'), pop: document.getElementById('pop'), idle: document.getElementById('idleWorkers') };
       const POP_CAP = 20;
-      function updateRes() { resUI.rice.textContent = players[0].res.rice | 0; resUI.water.textContent = players[0].res.water | 0; resUI.pop.textContent = players[0].units.filter(u => !u.dead && !u.isHero).length; }
+      function updateRes() {
+        resUI.rice.textContent = players[0].res.rice | 0;
+        resUI.water.textContent = players[0].res.water | 0;
+        resUI.pop.textContent = players[0].units.filter(u => !u.dead && !u.isHero).length;
+        resUI.idle.textContent = players[0].units.filter(u => u.type === 'worker' && u.state === 'idle').length;
+      }
 
       /* ==== Training & buildings ==== */
       const COSTS = { barracks: { rice: 180, water: 70 }, mBarracks: { rice: 220, water: 110 }, well: { rice: 140, water: 0 }, range: { rice: 160, water: 80 }, altar: { rice: 200, water: 140 } };
@@ -121,7 +126,8 @@ function drawWeather(dt) {
         }
       };
       function setHeroUI(h) {
-        if (!h) { heroPanel.style.display = 'none'; invPanel.style.display = 'none'; return; }
+        const othersSel = players[0].units.some(u => u.selected && u !== h) || players[0].structures.some(s => s.selected);
+        if (!h || h.dead || !h.selected || othersSel) { heroPanel.style.display = 'none'; invPanel.style.display = 'none'; return; }
         heroPanel.style.display = 'block'; invPanel.style.display = 'block';
         heroName.textContent = h.heroName + ' (' + h.heroClass + ')';
         heroHP.textContent = `HP ${h.hp | 0}/${h.maxHp | 0}`;
@@ -234,8 +240,13 @@ function drawWeather(dt) {
 
       /* ==== Input & selection ==== */
       const buildTip = document.getElementById('buildTip');
-      const input = { x: 0, y: 0, wx: 0, wy: 0, keys: {}, buildMode: null, lastClickT: 0, lastClickType: null };
-      cvs.addEventListener('mousemove', e => { input.x = e.offsetX; input.y = e.offsetY; const w = screenToWorld(input.x, input.y); input.wx = w.x; input.wy = w.y; });
+      const input = { x: 0, y: 0, wx: 0, wy: 0, keys: {}, buildMode: null, lastClickT: 0, lastClickType: null, rDown: false, rectStartX: 0, rectStartY: 0, rectStartWX: 0, rectStartWY: 0, rectSelecting: false };
+      cvs.addEventListener('mousemove', e => {
+        input.x = e.offsetX; input.y = e.offsetY; const w = screenToWorld(input.x, input.y); input.wx = w.x; input.wy = w.y;
+        if (input.rDown && !input.rectSelecting) {
+          if (Math.abs(e.offsetX - input.rectStartX) > 4 || Math.abs(e.offsetY - input.rectStartY) > 4) input.rectSelecting = true;
+        }
+      });
       cvs.addEventListener('contextmenu', e => { e.preventDefault(); if (input.buildMode) { input.buildMode = null; buildTip.style.display = 'none'; } });
       window.addEventListener('keydown', e => { const k = e.key.toLowerCase(); input.keys[k] = true; if (k === 'f') globalThis.fogEnabled = !globalThis.fogEnabled; if (k === '1') tryCast(1); if (k === '2') tryCast(2); if (k === '3') tryCast(3); if (k === 'u') { const h = players[0].hero; if (h && h.inventory.length) { const it = h.inventory.shift(); applyItem(h, it); renderInventory(h); } } if (k === 'r') { resumeWorkers(players[0]); } });
       window.addEventListener('keyup', e => { input.keys[e.key.toLowerCase()] = false; });
@@ -264,20 +275,44 @@ function drawWeather(dt) {
           }
           updatePanels();
         } else if (e.button === 2) {
-          if (input.buildMode) { input.buildMode = null; buildTip.style.display = 'none'; return; }
-          const sel = players[0].units.filter(u => u.selected && !u.dead);
-          const tgt = entityAt(input.wx, input.wy);
-          if (sel.length === 0 && tgt && tgt.owner === 0) {
-            unselectAll(); tgt.selected = true; updatePanels(); return;
+          input.rDown = true;
+          input.rectStartX = e.offsetX;
+          input.rectStartY = e.offsetY;
+          input.rectStartWX = input.wx;
+          input.rectStartWY = input.wy;
+        }
+      });
+
+      cvs.addEventListener('mouseup', e => {
+        if (e.button === 2) {
+          e.preventDefault();
+          if (input.rectSelecting) {
+            const x1 = Math.min(input.rectStartWX, input.wx), y1 = Math.min(input.rectStartWY, input.wy);
+            const x2 = Math.max(input.rectStartWX, input.wx), y2 = Math.max(input.rectStartWY, input.wy);
+            if (!e.shiftKey) unselectAll();
+            for (const u of players[0].units) {
+              if (u.dead) continue;
+              if (u.x >= x1 && u.x <= x2 && u.y >= y1 && u.y <= y2) u.selected = true;
+            }
+            updatePanels();
+          } else {
+            if (input.buildMode) { input.buildMode = null; buildTip.style.display = 'none'; input.rDown = false; return; }
+            const sel = players[0].units.filter(u => u.selected && !u.dead);
+            const tgt = entityAt(input.wx, input.wy);
+            if (sel.length === 0 && tgt && tgt.owner === 0) {
+              unselectAll(); tgt.selected = true; updatePanels(); input.rDown = false; return;
+            }
+            if (sel.length) {
+              if (tgt instanceof Structure && tgt.isGhost && sel.some(u => u.type === 'worker')) {
+                sel.filter(u => u.type === 'worker').forEach(w => { w.state = 'build'; w.buildTargetId = tgt.id; });
+              } else if (tgt instanceof ResourceNode && sel.some(u => u.type === 'worker')) {
+                sel.filter(u => u.type === 'worker').forEach(w => { w.role = tgt.type; w.state = 'idle'; });
+              } else if (tgt && tgt.owner !== 0) { sel.forEach(u => u.setTarget(tgt)); }
+              else { sel.forEach((u, i) => u.setDest(input.wx + i * 12, input.wy)); }
+            }
           }
-          if (sel.length) {
-            if (tgt instanceof Structure && tgt.isGhost && sel.some(u => u.type === 'worker')) {
-              sel.filter(u => u.type === 'worker').forEach(w => { w.state = 'build'; w.buildTargetId = tgt.id; });
-            } else if (tgt instanceof ResourceNode && sel.some(u => u.type === 'worker')) {
-              sel.filter(u => u.type === 'worker').forEach(w => { w.role = tgt.type; w.state = 'idle'; });
-            } else if (tgt && tgt.owner !== 0) { sel.forEach(u => u.setTarget(tgt)); }
-            else { sel.forEach((u, i) => u.setDest(input.wx + i * 12, input.wy)); }
-          }
+          input.rDown = false;
+          input.rectSelecting = false;
         }
       });
 
@@ -431,6 +466,14 @@ globalThis.drawHp = drawHp;
         for (const e of drawables) { if (e.draw) e.draw(); }
         drawWeather(dt);
         drawFog();
+        if (input.rectSelecting) {
+          const rx = Math.min(input.rectStartX, input.x);
+          const ry = Math.min(input.rectStartY, input.y);
+          const rw = Math.abs(input.rectStartX - input.x);
+          const rh = Math.abs(input.rectStartY - input.y);
+          ctx.strokeStyle = '#7ac8ff';
+          ctx.strokeRect(rx, ry, rw, rh);
+        }
         // cursor
         ctx.strokeStyle = 'rgba(255,255,255,0.5)'; ctx.beginPath(); const c = 8; ctx.moveTo(input.x - c, input.y); ctx.lineTo(input.x + c, input.y); ctx.moveTo(input.x, input.y - c); ctx.lineTo(input.x, input.y + c); ctx.stroke();
         drawMinimap();

--- a/src/ui.js
+++ b/src/ui.js
@@ -8,6 +8,8 @@ const btnFog = document.getElementById('btnFog');
 const resultMenu = document.getElementById('resultMenu');
 const resultText = document.getElementById('resultText');
 const btnResultRestart = document.getElementById('btnResultRestart');
+const idleWorkersEl = document.getElementById('idleWorkers');
+globalThis.idleWorkersEl = idleWorkersEl;
 
 globalThis.paused = true;
 globalThis.muted = false;


### PR DESCRIPTION
## Summary
- Show warning icon when workers lack HQ or resource node and reassign to new nodes
- Track idle workers in UI and display count
- Reduce unit movement speed and allow right-button drag selection; hero ability panel hides when hero not selected

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cea235fe883279f83ad48232b89c1