### PR TITLE
feat: add sprite system and terrain rendering

### DIFF
--- a/src/entities.js
+++ b/src/entities.js
@@ -242,6 +242,7 @@ export class Unit extends Entity {
     const s = globalThis.worldToScreen(this.x, this.y);
     const col = globalThis.players[this.owner]?.color || '#9fb2a1';
     const spr = this.isHero ? 'hero' : (this.type === 'archer' ? 'archer' : (this.type === 'mage' ? 'mage' : 'soldier'));
+    globalThis.drawShadow(s.x, s.y + 12 * globalThis.world.zoom, 12 * globalThis.world.zoom);
     globalThis.drawSprite(spr, s.x, s.y, globalThis.world.zoom * 1.25, { o: col });
     globalThis.drawHp(s.x, s.y - 18 * globalThis.world.zoom, this.hp / this.maxHp);
     if (this.auraTimer > 0) {
@@ -307,6 +308,7 @@ export class Structure extends Entity {
     const col = globalThis.players[this.owner]?.color || '#9fb2a1';
     const scale = globalThis.world.zoom * 5.25;
     const w = 16 * scale;
+    globalThis.drawShadow(s.x, s.y + w / 2, w / 2);
     globalThis.drawSprite('building', s.x, s.y, scale, { o: col });
     globalThis.drawHp(s.x, s.y - w / 2 - 10, this.hp / this.maxHp);
     if (this.selected) {
@@ -328,7 +330,8 @@ export class ResourceNode {
     if (!globalThis.isExplored(this.x, this.y)) return;
     const s = globalThis.worldToScreen(this.x, this.y);
     const scale = globalThis.world.zoom * (this.radius * 2 / 16);
-    globalThis.drawSprite(this.type === 'rice' ? 'rice' : 'water', s.x, s.y, scale);
+    globalThis.drawShadow(s.x, s.y + 8 * globalThis.world.zoom, this.radius * globalThis.world.zoom * 0.6);
+    globalThis.drawSprite(this.type === 'rice' ? 'rice' : 'waterNode', s.x, s.y, scale);
   }
 }
 

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,4 @@
-import "./sprites.js";
+import { drawSprite } from "./sprites.js";
 import { Unit, Structure, ResourceNode, ItemDrop, NeutralCreep, Projectile, getById, enemiesFor, allUnits, allStructures, nearestNode, lootFromTier } from "./entities.js";
 
 /* ==== Helpers ==== */
@@ -9,6 +9,7 @@ const dist2 = (x1, y1, x2, y2) => { const dx = x2 - x1, dy = y2 - y1; return dx 
 /* ==== Canvas & camera ==== */
 const cvs = document.getElementById('game'), ctx = cvs.getContext('2d'); ctx.imageSmoothingEnabled = false;
 const mini = document.getElementById('minimap'), mctx = mini.getContext('2d'); mctx.imageSmoothingEnabled = false;
+globalThis.drawSprite = (name, x, y, scale = 1, override = {}) => drawSprite(ctx, name, x, y, { scale, override });
 const DPR = Math.max(1, window.devicePixelRatio || 1);
 const world = { width: 12000, height: 8000, camX: 0, camY: 0, zoom: 1.25 };
 function resize() { const w = cvs.clientWidth, h = cvs.clientHeight; cvs.width = Math.floor(w * DPR); cvs.height = Math.floor(h * DPR); ctx.setTransform(DPR, 0, 0, DPR, 0, 0); }
@@ -31,7 +32,9 @@ cvs.addEventListener('wheel', e => {
   clampCam();
 }, { passive: false });
 
-Object.assign(globalThis, { clamp, rand, dist2, cvs, ctx, mini, mctx, DPR, world, screenToWorld, worldToScreen, clampCam });
+function toPixel(v) { return Math.round(v * DPR) / DPR; }
+function drawShadow(x, y, r) { ctx.save(); ctx.fillStyle = 'rgba(0,0,0,0.25)'; ctx.beginPath(); ctx.ellipse(toPixel(x), toPixel(y), r, r * 0.5, 0, 0, Math.PI * 2); ctx.fill(); ctx.restore(); }
+Object.assign(globalThis, { clamp, rand, dist2, cvs, ctx, mini, mctx, DPR, world, screenToWorld, worldToScreen, clampCam, toPixel, drawShadow });
 
 /* ==== Audio (простые огибающие без внешних файлов) ==== */
 const AC = window.AudioContext ? new AudioContext() : null;
@@ -240,10 +243,10 @@ function drawWeather(dt) {
 
       /* ==== Input & selection ==== */
       const buildTip = document.getElementById('buildTip');
-      const input = { x: 0, y: 0, wx: 0, wy: 0, keys: {}, buildMode: null, lastClickT: 0, lastClickType: null, rDown: false, rectStartX: 0, rectStartY: 0, rectStartWX: 0, rectStartWY: 0, rectSelecting: false };
+      const input = { x: 0, y: 0, wx: 0, wy: 0, keys: {}, buildMode: null, lastClickT: 0, lastClickType: null, lDown: false, rectStartX: 0, rectStartY: 0, rectStartWX: 0, rectStartWY: 0, rectSelecting: false };
       cvs.addEventListener('mousemove', e => {
         input.x = e.offsetX; input.y = e.offsetY; const w = screenToWorld(input.x, input.y); input.wx = w.x; input.wy = w.y;
-        if (input.rDown && !input.rectSelecting) {
+        if (input.lDown && !input.rectSelecting) {
           if (Math.abs(e.offsetX - input.rectStartX) > 4 || Math.abs(e.offsetY - input.rectStartY) > 4) input.rectSelecting = true;
         }
       });
@@ -264,28 +267,19 @@ function drawWeather(dt) {
 
       cvs.addEventListener('mousedown', e => {
         if (e.button === 0) {
-          const now = performance.now();
-          if (input.buildMode) { const ok = placeGhost(0, input.wx, input.wy, input.buildMode); if (ok) { input.buildMode = null; buildTip.style.display = 'none'; } return; }
-          const hit = entityAt(input.wx, input.wy);
-          if (!e.shiftKey) unselectAll();
-          if (hit) {
-            hit.selected = true;
-            if (now - input.lastClickT < 300 && input.lastClickType === hit.type) { selectSameTypeOnScreen(hit.type); }
-            input.lastClickType = hit.type; input.lastClickT = now;
-          }
-          updatePanels();
-        } else if (e.button === 2) {
-          input.rDown = true;
+          input.lDown = true;
           input.rectStartX = e.offsetX;
           input.rectStartY = e.offsetY;
           input.rectStartWX = input.wx;
           input.rectStartWY = input.wy;
+        } else if (e.button === 2) {
+          e.preventDefault();
+          if (input.buildMode) { input.buildMode = null; buildTip.style.display = 'none'; }
         }
       });
 
       cvs.addEventListener('mouseup', e => {
-        if (e.button === 2) {
-          e.preventDefault();
+        if (e.button === 0) {
           if (input.rectSelecting) {
             const x1 = Math.min(input.rectStartWX, input.wx), y1 = Math.min(input.rectStartWY, input.wy);
             const x2 = Math.max(input.rectStartWX, input.wx), y2 = Math.max(input.rectStartWY, input.wy);
@@ -296,23 +290,37 @@ function drawWeather(dt) {
             }
             updatePanels();
           } else {
-            if (input.buildMode) { input.buildMode = null; buildTip.style.display = 'none'; input.rDown = false; return; }
-            const sel = players[0].units.filter(u => u.selected && !u.dead);
-            const tgt = entityAt(input.wx, input.wy);
-            if (sel.length === 0 && tgt && tgt.owner === 0) {
-              unselectAll(); tgt.selected = true; updatePanels(); input.rDown = false; return;
-            }
-            if (sel.length) {
-              if (tgt instanceof Structure && tgt.isGhost && sel.some(u => u.type === 'worker')) {
-                sel.filter(u => u.type === 'worker').forEach(w => { w.state = 'build'; w.buildTargetId = tgt.id; });
-              } else if (tgt instanceof ResourceNode && sel.some(u => u.type === 'worker')) {
-                sel.filter(u => u.type === 'worker').forEach(w => { w.role = tgt.type; w.state = 'idle'; });
-              } else if (tgt && tgt.owner !== 0) { sel.forEach(u => u.setTarget(tgt)); }
-              else { sel.forEach((u, i) => u.setDest(input.wx + i * 12, input.wy)); }
+            if (input.buildMode) {
+              const ok = placeGhost(0, input.wx, input.wy, input.buildMode);
+              if (ok) { input.buildMode = null; buildTip.style.display = 'none'; }
+            } else {
+              const hit = entityAt(input.wx, input.wy);
+              const now = performance.now();
+              if (hit) {
+                if (!e.shiftKey) unselectAll();
+                hit.selected = true;
+                if (now - input.lastClickT < 300 && input.lastClickType === hit.type) { selectSameTypeOnScreen(hit.type); }
+                input.lastClickType = hit.type; input.lastClickT = now;
+                updatePanels();
+              }
             }
           }
-          input.rDown = false;
+          input.lDown = false;
           input.rectSelecting = false;
+        } else if (e.button === 2) {
+          e.preventDefault();
+          if (input.buildMode) { input.buildMode = null; buildTip.style.display = 'none'; return; }
+          const sel = players[0].units.filter(u => u.selected && !u.dead);
+          const tgt = entityAt(input.wx, input.wy);
+          if (sel.length === 0 && tgt && tgt.owner === 0) { unselectAll(); tgt.selected = true; updatePanels(); return; }
+          if (sel.length) {
+            if (tgt instanceof Structure && tgt.isGhost && sel.some(u => u.type === 'worker')) {
+              sel.filter(u => u.type === 'worker').forEach(w => { w.state = 'build'; w.buildTargetId = tgt.id; });
+            } else if (tgt instanceof ResourceNode && sel.some(u => u.type === 'worker')) {
+              sel.filter(u => u.type === 'worker').forEach(w => { w.role = tgt.type; w.state = 'idle'; });
+            } else if (tgt && tgt.owner !== 0) { sel.forEach(u => u.setTarget(tgt)); }
+            else { sel.forEach((u, i) => u.setDest(input.wx + i * 12, input.wy)); }
+          }
         }
       });
 
@@ -371,8 +379,19 @@ function drawWeather(dt) {
       /* ==== Minimap ==== */
       mini.addEventListener('click', e => { const r = mini.getBoundingClientRect(); const mx = (e.clientX - r.left) / r.width, my = (e.clientY - r.top) / r.height; world.camX = mx * world.width - (cvs.width / DPR) / world.zoom / 2; world.camY = my * world.height - (cvs.height / DPR) / world.zoom / 2; });
       function drawMinimap() {
-        const img = mctx.createImageData(mini.width, mini.height); for (let y = 0; y < mini.height; y++) { for (let x = 0; x < mini.width; x++) { const idx = (y * mini.width + x) * 4; img.data[idx] = 0; img.data[idx + 1] = 60; img.data[idx + 2] = 10; img.data[idx + 3] = 255; } } mctx.putImageData(img, 0, 0);
-        function dot(x, y, col) { mctx.fillStyle = col; mctx.fillRect(x - 1, y - 1, 2, 2); }
+        const img = mctx.createImageData(mini.width, mini.height);
+        for (let y = 0; y < mini.height; y++) {
+          for (let x = 0; x < mini.width; x++) {
+            const idx = (y * mini.width + x) * 4;
+            const h = (x * 73856093 ^ y * 19349663) & 255;
+            img.data[idx] = 20 + (h & 31);
+            img.data[idx + 1] = 100 + (h & 63);
+            img.data[idx + 2] = 20 + (h & 31);
+            img.data[idx + 3] = 255;
+          }
+        }
+        mctx.putImageData(img, 0, 0);
+        function dot(x, y, col) { mctx.fillStyle = col; mctx.fillRect(x | 0, y | 0, 2, 2); }
         for (const p of players) { for (const s of p.structures) { if (!isExplored(s.x, s.y)) continue; dot(s.x / world.width * mini.width, s.y / world.height * mini.height, p.color); } for (const u of p.units) { if (!isExplored(u.x, u.y)) continue; dot(u.x / world.width * mini.width, u.y / world.height * mini.height, p.color); } }
         for (const n of neutral.units) { if (!isExplored(n.x, n.y)) continue; dot(n.x / world.width * mini.width, n.y / world.height * mini.height, '#9fb2a1'); }
         mctx.strokeStyle = 'rgba(255,255,255,.8)'; mctx.lineWidth = 1; const rx = world.camX / world.width * mini.width, ry = world.camY / world.height * mini.height; const rw = (cvs.width / DPR) / world.zoom / world.width * mini.width, rh = (cvs.height / DPR) / world.zoom / world.height * mini.height; mctx.strokeRect(rx, ry, rw, rh);
@@ -462,8 +481,12 @@ globalThis.drawHp = drawHp;
         }
         ctx.clearRect(0, 0, cvs.width, cvs.height);
         drawTerrain();
-        const drawables = allStructures().concat(allUnits(), neutral.units, projectiles, riceNodes, waterNodes, drops); drawables.sort((a, b) => a.y - b.y);
+        for (const n of riceNodes) n.draw();
+        for (const n of waterNodes) n.draw();
+        if (globalThis.drawBlockers) globalThis.drawBlockers();
+        const drawables = allStructures().concat(allUnits(), neutral.units, drops); drawables.sort((a, b) => a.y - b.y);
         for (const e of drawables) { if (e.draw) e.draw(); }
+        for (const pr of projectiles) pr.draw();
         drawWeather(dt);
         drawFog();
         if (input.rectSelecting) {

--- a/src/sprites.js
+++ b/src/sprites.js
@@ -1,5 +1,5 @@
-/* Simple pixel sprites and drawing helper */
-const PALETTE = {
+// Pixel sprite system
+export const PALETTE = {
   g: '#3b7a3b',
   G: '#2e642e',
   w: '#83b9d4',
@@ -9,10 +9,11 @@ const PALETTE = {
   t: '#5d3a1a',
   T: '#2e7d32',
   s: '#f1c27d',
-  b: '#8b5a2b'
+  b: '#8b5a2b',
+  o: '#9fb2a1'
 };
 
-const SPRITES = {
+export const SPRITES = {
   grass: [
     "gGgggGggggGggggg",
     "gggggGgggggggggg",
@@ -49,24 +50,6 @@ const SPRITES = {
     "wwWWwwWWwwWWwwWW",
     "WWwwWWwwWWwwWWww"
   ],
-  rice: [
-    "rrrrrrrrrrrrrrrr",
-    "rRrRrRrRrRrRrRrR",
-    "rrrrrrrrrrrrrrrr",
-    "rRrRrRrRrRrRrRrR",
-    "rrrrrrrrrrrrrrrr",
-    "rRrRrRrRrRrRrRrR",
-    "rrrrrrrrrrrrrrrr",
-    "rRrRrRrRrRrRrRrR",
-    "rrrrrrrrrrrrrrrr",
-    "rRrRrRrRrRrRrRrR",
-    "rrrrrrrrrrrrrrrr",
-    "rRrRrRrRrRrRrRrR",
-    "rrrrrrrrrrrrrrrr",
-    "rRrRrRrRrRrRrRrR",
-    "rrrrrrrrrrrrrrrr",
-    "rRrRrRrRrRrRrRrR"
-  ],
   tree: [
     ".......T.......",
     "......TTT......",
@@ -85,23 +68,41 @@ const SPRITES = {
     "......TTT......",
     "......TTT......"
   ],
-  unit: [
-    "................",
-    ".......s........",
-    "......sss.......",
-    "......sss.......",
-    ".......s........",
-    "....ooooooo.....",
-    "...ooooooooo....",
-    "...ooooooooo....",
-    "...ooooooooo....",
-    "...ooooooooo....",
-    "....ooooooo.....",
-    ".......o........",
-    "......o.o.......",
-    ".....o...o......",
-    "................",
-    "................"
+  rice: [
+    "rrrrrrrrrrrrrrrr",
+    "rRrRrRrRrRrRrRrR",
+    "rrrrrrrrrrrrrrrr",
+    "rRrRrRrRrRrRrRrR",
+    "rrrrrrrrrrrrrrrr",
+    "rRrRrRrRrRrRrRrR",
+    "rrrrrrrrrrrrrrrr",
+    "rRrRrRrRrRrRrRrR",
+    "rrrrrrrrrrrrrrrr",
+    "rRrRrRrRrRrRrRrR",
+    "rrrrrrrrrrrrrrrr",
+    "rRrRrRrRrRrRrRrR",
+    "rrrrrrrrrrrrrrrr",
+    "rRrRrRrRrRrRrRrR",
+    "rrrrrrrrrrrrrrrr",
+    "rRrRrRrRrRrRrRrR"
+  ],
+  waterNode: [
+    "......WWWW......",
+    "....WWwwwwWW....",
+    "...WwwwwwwwwW...",
+    "..WwwwwwwwwwwW..",
+    "..WwwwwwwwwwwW..",
+    "...WwwwwwwwwW...",
+    "....WWwwwwWW....",
+    "......WWWW......",
+    "......WWWW......",
+    "....WWwwwwWW....",
+    "...WwwwwwwwwW...",
+    "..WwwwwwwwwwwW..",
+    "..WwwwwwwwwwwW..",
+    "...WwwwwwwwwW...",
+    "....WWwwwwWW....",
+    "......WWWW......"
   ],
   soldier: [
     "................",
@@ -213,22 +214,79 @@ const SPRITES = {
   ]
 };
 
-function drawSprite(name, x, y, scale = 1, override = {}) {
+const CACHE = new Map();
+
+export function drawSprite(ctx, name, x, y, opts = {}) {
   const spr = SPRITES[name];
   if (!spr) return;
-  const h = spr.length;
+  const {
+    scale = 1,
+    alpha = 1,
+    flipX = false,
+    flipY = false,
+    rotate = 0,
+    anchor = 'center',
+    shadow = false,
+    override = {}
+  } = opts;
   const w = spr[0].length;
-  const ctx = globalThis.ctx;
-  for (let j = 0; j < h; j++) {
-    const row = spr[j];
-    for (let i = 0; i < w; i++) {
-      const ch = row[i];
-      if (ch === '.') continue;
-      const color = override[ch] || PALETTE[ch] || '#000';
-      ctx.fillStyle = color;
-      ctx.fillRect(x + (i - w / 2) * scale, y + (j - h / 2) * scale, scale, scale);
+  const h = spr.length;
+  let canvas = null;
+  if (!flipX && !flipY && !rotate && alpha === 1 && !shadow) {
+    const key = name + '@' + scale + '@' + JSON.stringify(override);
+    canvas = CACHE.get(key);
+    if (!canvas) {
+      canvas = document.createElement('canvas');
+      canvas.width = w * scale;
+      canvas.height = h * scale;
+      const cctx = canvas.getContext('2d');
+      cctx.imageSmoothingEnabled = false;
+      for (let j = 0; j < h; j++) {
+        const row = spr[j];
+        for (let i = 0; i < w; i++) {
+          const ch = row[i];
+          if (ch === '.') continue;
+          const color = override[ch] || PALETTE[ch] || '#000';
+          cctx.fillStyle = color;
+          cctx.fillRect(i * scale, j * scale, scale, scale);
+        }
+      }
+      CACHE.set(key, canvas);
     }
   }
+  const tp = globalThis.toPixel || (v => v);
+  const px = tp(x);
+  const py = tp(y);
+  ctx.save();
+  ctx.imageSmoothingEnabled = false;
+  ctx.globalAlpha *= alpha;
+  if (shadow && globalThis.drawShadow) {
+    const r = (w * scale) / 2;
+    globalThis.drawShadow(px, py + r * 0.6, r);
+  }
+  ctx.translate(px, py);
+  if (rotate) ctx.rotate(rotate);
+  ctx.scale(flipX ? -1 : 1, flipY ? -1 : 1);
+  const ox = anchor === 'center' ? -w * scale / 2 : 0;
+  const oy = anchor === 'center' ? -h * scale / 2 : 0;
+  if (canvas) {
+    ctx.drawImage(canvas, ox, oy);
+  } else {
+    for (let j = 0; j < h; j++) {
+      const row = spr[j];
+      for (let i = 0; i < w; i++) {
+        const ch = row[i];
+        if (ch === '.') continue;
+        const color = override[ch] || PALETTE[ch] || '#000';
+        ctx.fillStyle = color;
+        ctx.fillRect(ox + i * scale, oy + j * scale, scale, scale);
+      }
+    }
+  }
+  ctx.restore();
 }
 
-Object.assign(globalThis, { drawSprite });
+export function drawSpriteLegacy(name, x, y, scale = 1, override = {}) {
+  if (!globalThis.ctx) return;
+  drawSprite(globalThis.ctx, name, x, y, { scale, override });
+}

--- a/src/terrain.js
+++ b/src/terrain.js
@@ -1,7 +1,40 @@
-/* ==== Simple terrain + blockers (лес/река) ==== */
-// Генерим «реки» (непроходимые) как вертикальные полосы и «лес» как кучки препятствий
+import { drawSprite } from './sprites.js';
+
+/* ==== Terrain generation and blockers ==== */
 const blockers = []; // {x,y,r,kind}
-function genBlockers() {
+
+const TILE = 64;
+const grassTile = document.createElement('canvas');
+grassTile.width = TILE; grassTile.height = TILE;
+const gctx = grassTile.getContext('2d');
+gctx.imageSmoothingEnabled = false;
+drawSprite(gctx, 'grass', TILE / 2, TILE / 2, { scale: 4 });
+
+const waterTile = document.createElement('canvas');
+waterTile.width = TILE; waterTile.height = TILE;
+const wctx = waterTile.getContext('2d');
+wctx.imageSmoothingEnabled = false;
+drawSprite(wctx, 'water', TILE / 2, TILE / 2, { scale: 4 });
+
+const treeBase = document.createElement('canvas');
+treeBase.width = 16; treeBase.height = 16;
+const tctx = treeBase.getContext('2d');
+tctx.imageSmoothingEnabled = false;
+drawSprite(tctx, 'tree', 8, 8);
+
+const waterBase = document.createElement('canvas');
+waterBase.width = 16; waterBase.height = 16;
+const wbctx = waterBase.getContext('2d');
+wbctx.imageSmoothingEnabled = false;
+drawSprite(wbctx, 'water', 8, 8);
+
+function hash(x, y) {
+  let h = x * 374761393 + y * 668265263;
+  h = (h ^ (h >> 13)) >>> 0;
+  return h;
+}
+
+export function genBlockers() {
   const { rand, clamp, world } = globalThis;
   blockers.length = 0;
   for (let i = 0; i < 2; i++) {
@@ -14,31 +47,49 @@ function genBlockers() {
     blockers.push({ x: rand(600, world.width - 600), y: rand(600, world.height - 600), r: clamp(rand(24, 60), 24, 60), kind: 'tree' });
   }
 }
-function drawTerrain() {
-  const { world, cvs, worldToScreen } = globalThis;
-  const step = 64;
-  const startX = Math.floor(world.camX / step) * step,
-        startY = Math.floor(world.camY / step) * step,
-        endX = world.camX + cvs.width / world.zoom,
-        endY = world.camY + cvs.height / world.zoom;
+
+export function drawTerrain() {
+  const { world, cvs, worldToScreen, ctx, toPixel } = globalThis;
+  const step = TILE;
+  const startX = Math.floor(world.camX / step) * step;
+  const startY = Math.floor(world.camY / step) * step;
+  const endX = world.camX + cvs.width / world.zoom;
+  const endY = world.camY + cvs.height / world.zoom;
   for (let y = startY; y <= endY; y += step) {
     for (let x = startX; x <= endX; x += step) {
-      const s = worldToScreen(x + step / 2, y + step / 2);
-      globalThis.drawSprite('grass', s.x, s.y, world.zoom * 4);
+      const s = worldToScreen(x, y);
+      const dx = toPixel ? toPixel(s.x) : s.x;
+      const dy = toPixel ? toPixel(s.y) : s.y;
+      const size = step * world.zoom;
+      ctx.drawImage(grassTile, dx, dy, size, size);
+      const tx = Math.floor(x / step), ty = Math.floor(y / step);
+      if ((hash(tx, ty) & 255) < 10) ctx.drawImage(waterTile, dx, dy, size, size);
     }
   }
-  // реки/лес
+}
+
+export function drawBlockers() {
+  const { worldToScreen, world, ctx, drawShadow, toPixel } = globalThis;
   for (const b of blockers) {
-    const s = worldToScreen(b.x, b.y);
-    const sc = world.zoom * (b.r / 8);
-    globalThis.drawSprite(b.kind === 'water' ? 'water' : 'tree', s.x, s.y, sc);
+    const size = b.r * 2 * world.zoom;
+    const topLeft = worldToScreen(b.x - b.r, b.y - b.r);
+    const dx = toPixel ? toPixel(topLeft.x) : topLeft.x;
+    const dy = toPixel ? toPixel(topLeft.y) : topLeft.y;
+    if (b.kind === 'tree') {
+      drawShadow(topLeft.x + size / 2, topLeft.y + size * 0.75, size * 0.5);
+      ctx.drawImage(treeBase, dx, dy, size, size);
+    } else {
+      ctx.drawImage(waterBase, dx, dy, size, size);
+    }
   }
 }
-function isBlocked(wx, wy) {
+
+export function isBlocked(wx, wy) {
   const { dist2 } = globalThis;
   for (const b of blockers) {
     if (dist2(wx, wy, b.x, b.y) <= (b.r + 10) * (b.r + 10)) return true;
   }
   return false;
 }
-Object.assign(globalThis, { blockers, genBlockers, drawTerrain, isBlocked });
+
+Object.assign(globalThis, { blockers, genBlockers, drawTerrain, drawBlockers, isBlocked });


### PR DESCRIPTION
## Summary
- implement sprite module with palette, caching and legacy wrapper
- tile terrain rendering with cached grass/water and blocker shadows
- overhaul selection to use left drag and keep selection
- add pixel-perfect helpers and noisy minimap background

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cf15a97f88327bdee382cd0897883