### PR TITLE
Refactor unit visuals and AI base rebuilding

### DIFF
--- a/src/ai.js
+++ b/src/ai.js
@@ -36,7 +36,17 @@ function aiThink(dt, id) {
   if (!players[id].ai) return;
   if (!players[id].aiPlan) aiInitPlan(players[id]);
   const P = players[id];
-  const HQ = P.structures.find(s => s.kind === 'hq');
+  let HQ = P.structures.find(s => s.kind === 'hq' || s.kind === 'square');
+  if (!HQ) {
+    const cost = COSTS.square;
+    const px = P.startX || 0, py = P.startY || 0;
+    if (P.res.rice >= cost.rice && P.res.water >= cost.water && !isBlocked(px, py) && placeGhost(id, px, py, 'square')) {
+      const g = P.structures.find(s => s.isGhost && s.kind === 'square');
+      const w = P.units.find(u => u.type === 'worker');
+      if (g && w) { w.state = 'build'; w.buildTargetId = g.id; }
+    }
+    HQ = P.structures.find(s => s.kind === 'square');
+  }
   // buildings
   if (P.aiPlan.nextBuild < P.aiPlan.open.length && HQ) {
     const kind = P.aiPlan.open[P.aiPlan.nextBuild]; const cost = COSTS[kind];

--- a/src/entities.js
+++ b/src/entities.js
@@ -102,7 +102,7 @@ export class Unit extends Entity {
   updateWorker(dt) {
     if (this.role !== 'rice' && this.role !== 'water') return;
     const P = globalThis.players[this.owner];
-    const HQ = P.structures.find(s => s.kind === 'hq');
+    const HQ = P.structures.find(s => s.kind === 'hq' || s.kind === 'square');
     if (!HQ) { this.state = 'idle'; this.noteTimer = 2; return; }
     const node = (this.role === 'rice' ? nearestNode('rice', P) : nearestNode('water', P));
     if (!node) { this.state = 'idle'; this.noteTimer = 2; this.nodeId = null; return; }
@@ -156,7 +156,7 @@ export class Unit extends Entity {
   }
   updateRetreat(dt) {
     if (this.owner !== 0 && !this.isHero) {
-      const HQ = globalThis.players[this.owner].structures.find(s => s.kind === 'hq');
+      const HQ = globalThis.players[this.owner].structures.find(s => s.kind === 'hq' || s.kind === 'square');
       if (this.hp / this.maxHp < 0.35) {
         this.retreat = true;
         if (HQ) this.setDest(HQ.x, HQ.y + 40);
@@ -240,33 +240,59 @@ export class Unit extends Entity {
   draw() {
     if (this.owner !== 0 && !globalThis.isVisible(this.x, this.y)) return;
     const s = globalThis.worldToScreen(this.x, this.y);
+    const zoom = globalThis.world.zoom;
+    const ctx = globalThis.ctx;
     const col = globalThis.players[this.owner]?.color || '#9fb2a1';
-    const spr = this.isHero ? 'hero' : (this.type === 'archer' ? 'archer' : (this.type === 'mage' ? 'mage' : 'soldier'));
-    globalThis.drawShadow(s.x, s.y + 12 * globalThis.world.zoom, 12 * globalThis.world.zoom);
-    globalThis.drawSprite(spr, s.x, s.y, globalThis.world.zoom * 1.25, { o: col });
-    globalThis.drawHp(s.x, s.y - 18 * globalThis.world.zoom, this.hp / this.maxHp);
+    globalThis.drawShadow(s.x, s.y + 12 * zoom, 12 * zoom);
+    ctx.save();
+    ctx.translate(s.x, s.y);
+    ctx.scale(zoom, zoom);
+    const grad = ctx.createLinearGradient(0, -12, 0, 12);
+    grad.addColorStop(0, '#f0f0f0');
+    grad.addColorStop(1, '#bdbdbd');
+    ctx.fillStyle = grad;
+    ctx.beginPath();
+    ctx.arc(0, -8, 8, Math.PI, 0);
+    ctx.lineTo(8, 8);
+    ctx.arc(0, 8, 8, 0, Math.PI);
+    ctx.closePath();
+    ctx.fill();
+    ctx.fillStyle = col;
+    ctx.fillRect(-8, -2, 16, 4);
+    if (this.type === 'soldier') {
+      ctx.fillStyle = '#ccc';
+      ctx.fillRect(-12, -4, 4, 8);
+    }
+    if (this.type === 'mage') {
+      ctx.fillStyle = '#8ad';
+      ctx.beginPath();
+      ctx.arc(0, -14, 4, 0, 6.283);
+      ctx.fill();
+    }
+    ctx.restore();
+    globalThis.drawHp(s.x, s.y - 18 * zoom, this.hp / this.maxHp);
     if (this.auraTimer > 0) {
-      globalThis.ctx.strokeStyle = 'rgba(255,215,0,0.5)';
-      globalThis.ctx.beginPath();
-      globalThis.ctx.arc(s.x, s.y, 80 * globalThis.world.zoom, 0, 6.283);
-      globalThis.ctx.stroke();
+      ctx.strokeStyle = 'rgba(255,215,0,0.5)';
+      ctx.beginPath();
+      ctx.arc(s.x, s.y, 80 * zoom, 0, 6.283);
+      ctx.stroke();
     }
     if (this.isHero) {
-      globalThis.ctx.strokeStyle = '#ffd27a';
-      globalThis.ctx.beginPath();
-      globalThis.ctx.arc(s.x, s.y, 14 * globalThis.world.zoom, 0, 6.283);
-      globalThis.ctx.stroke();
+      ctx.strokeStyle = '#ffd27a';
+      ctx.beginPath();
+      ctx.arc(s.x, s.y, 14 * zoom, 0, 6.283);
+      ctx.stroke();
     }
     if (this.selected) {
-      globalThis.ctx.strokeStyle = '#7ac8ff';
-      globalThis.ctx.beginPath();
-      globalThis.ctx.arc(s.x, s.y, 16 * globalThis.world.zoom, 0, 6.283);
-      globalThis.ctx.stroke();
+      ctx.strokeStyle = '#7ac8ff';
+      ctx.beginPath();
+      ctx.arc(s.x, s.y, 16 * zoom, 0, 6.283);
+      ctx.stroke();
     }
     if (this.noteTimer > 0 && this.type === 'worker') {
-      globalThis.ctx.fillStyle = '#ffd27a';
-      globalThis.ctx.font = `${12 * globalThis.world.zoom}px sans-serif`;
-      globalThis.ctx.fillText('!', s.x - 3 * globalThis.world.zoom, s.y - 20 * globalThis.world.zoom);
+      ctx.fillStyle = '#ffd27a';
+      ctx.font = `${12 * zoom}px sans-serif`;
+      ctx.fillText('!', s.x - 3 * zoom, s.y - 20 * zoom);
     }
   }
 }
@@ -289,15 +315,22 @@ export class Structure extends Entity {
       return;
     }
     if (this.queue.length > 0) {
-      if (this.qTime <= 0) this.qTime = 2.0;
+      if (this.qTime <= 0) this.qTime = this.queue[0] === 'hero' ? 20.0 : 2.0;
       this.qTime -= dt;
       if (this.qTime <= 0) {
-        const u = this.queue[0];
-        if (globalThis.trainUnit(this.owner, this, u)) {
-          this.queue.shift();
+        const u = this.queue.shift();
+        if (u === 'hero') {
+          if (!globalThis.players[this.owner].hero || globalThis.players[this.owner].hero.dead) {
+            globalThis.spawnHero(this.owner, this.x + 40, this.y - 20, globalThis.players[this.owner].chosenClass);
+          }
           this.qTime = 0;
         } else {
-          this.qTime = 1.0;
+          if (globalThis.trainUnit(this.owner, this, u)) {
+            this.qTime = 0;
+          } else {
+            this.qTime = 1.0;
+            this.queue.unshift(u);
+          }
         }
       }
     }
@@ -314,6 +347,25 @@ export class Structure extends Entity {
     if (this.selected) {
       globalThis.ctx.strokeStyle = '#7ac8ff';
       globalThis.ctx.strokeRect(s.x - w / 2 - 4, s.y - w / 2 - 4, w + 8, w + 8);
+    }
+    if (this.queue.length > 0) {
+      const ctx = globalThis.ctx;
+      const zoom = globalThis.world.zoom;
+      const barY = s.y + w / 2 + 6 * zoom;
+      const total = this.queue[0] === 'hero' ? 20.0 : 2.0;
+      const prog = globalThis.clamp(1 - this.qTime / total, 0, 1);
+      ctx.fillStyle = 'rgba(0,0,0,0.6)';
+      ctx.fillRect(s.x - w / 2, barY, w, 4 * zoom);
+      ctx.fillStyle = '#6be36b';
+      ctx.fillRect(s.x - w / 2, barY, w * prog, 4 * zoom);
+      ctx.strokeStyle = 'rgba(255,255,255,0.3)';
+      ctx.strokeRect(s.x - w / 2, barY, w, 4 * zoom);
+      ctx.fillStyle = '#fff';
+      ctx.font = `${10 * zoom}px sans-serif`;
+      ctx.fillText(this.qTime.toFixed(1), s.x - w / 2, barY - 2 * zoom);
+      if (this.queue.length > 1) {
+        ctx.fillText('+' + (this.queue.length - 1), s.x + w / 2 + 4 * zoom, barY + 3 * zoom);
+      }
     }
   }
 }
@@ -434,14 +486,38 @@ export class NeutralCreep extends Entity {
     }
   }
   draw() {
-    if (!globalThis.isExplored(this.x, this.y)) return;
+    if (!globalThis.isVisible(this.x, this.y)) return;
     const s = globalThis.worldToScreen(this.x, this.y);
-    let col = '#9fb2a1';
-    if (this.kind === 'mage') col = '#8ad';
-    else if (this.kind === 'gnome') col = '#b86';
-    else if (this.kind === 'troll') col = '#a44';
-    globalThis.drawSprite('unit', s.x, s.y, globalThis.world.zoom * 1.25, { o: col });
-    globalThis.drawHp(s.x, s.y - 18 * globalThis.world.zoom, this.hp / this.maxHp);
+    const ctx = globalThis.ctx;
+    const zoom = globalThis.world.zoom;
+    let band = '#9fb2a1';
+    if (this.kind === 'mage') band = '#8ad';
+    else if (this.kind === 'gnome') band = '#b86';
+    else if (this.kind === 'troll') band = '#a44';
+    globalThis.drawShadow(s.x, s.y + 12 * zoom, 12 * zoom);
+    ctx.save();
+    ctx.translate(s.x, s.y);
+    ctx.scale(zoom, zoom);
+    const grad = ctx.createLinearGradient(0, -12, 0, 12);
+    grad.addColorStop(0, '#f0f0f0');
+    grad.addColorStop(1, '#bdbdbd');
+    ctx.fillStyle = grad;
+    ctx.beginPath();
+    ctx.arc(0, -8, 8, Math.PI, 0);
+    ctx.lineTo(8, 8);
+    ctx.arc(0, 8, 8, 0, Math.PI);
+    ctx.closePath();
+    ctx.fill();
+    ctx.fillStyle = band;
+    ctx.fillRect(-8, -2, 16, 4);
+    if (this.kind === 'mage') {
+      ctx.fillStyle = '#8ad';
+      ctx.beginPath();
+      ctx.arc(0, -14, 4, 0, 6.283);
+      ctx.fill();
+    }
+    ctx.restore();
+    globalThis.drawHp(s.x, s.y - 18 * zoom, this.hp / this.maxHp);
   }
 }
 
@@ -475,10 +551,11 @@ export function allStructures() {
 
 export function nearestNode(type, P) {
   const arr = (type === 'rice' ? globalThis.riceNodes : globalThis.waterNodes);
-  if (!P.structures || P.structures.length === 0) return null;
+  const base = P.structures.find(s => s.kind === 'hq' || s.kind === 'square');
+  if (!base) return null;
   let best = null, bd = 1e9;
   for (const n of arr) {
-    const d = globalThis.dist2(P.structures[0].x, P.structures[0].y, n.x, n.y);
+    const d = globalThis.dist2(base.x, base.y, n.x, n.y);
     if (d < bd) { bd = d; best = n; }
   }
   return best;

--- a/src/main.js
+++ b/src/main.js
@@ -93,7 +93,7 @@ function drawWeather(dt) {
       }
 
       /* ==== Training & buildings ==== */
-      const COSTS = { barracks: { rice: 180, water: 70 }, mBarracks: { rice: 220, water: 110 }, well: { rice: 140, water: 0 }, range: { rice: 160, water: 80 }, altar: { rice: 200, water: 140 } };
+      const COSTS = { barracks: { rice: 180, water: 70 }, mBarracks: { rice: 220, water: 110 }, well: { rice: 140, water: 0 }, range: { rice: 160, water: 80 }, altar: { rice: 200, water: 140 }, square: { rice: 220, water: 120 } };
       function placeGhost(owner, x, y, kind) { const cost = COSTS[kind] || { rice: 0, water: 0 }; const R = players[owner].res; if (R.rice < cost.rice || R.water < cost.water) return false; if (isBlocked(x, y)) return false; R.rice -= cost.rice; if (owner === 0) updateRes(); const g = new Structure(x, y, owner, kind, true); players[owner].structures.push(g); return true; }
       function trainUnit(owner, barr, unitType) {
         if (players[owner].units.filter(u => !u.dead && !u.isHero).length >= POP_CAP) return false;
@@ -129,8 +129,7 @@ function drawWeather(dt) {
         }
       };
       function setHeroUI(h) {
-        const othersSel = players[0].units.some(u => u.selected && u !== h) || players[0].structures.some(s => s.selected);
-        if (!h || h.dead || !h.selected || othersSel) { heroPanel.style.display = 'none'; invPanel.style.display = 'none'; return; }
+        if (!h || h.dead || !h.selected) { heroPanel.style.display = 'none'; invPanel.style.display = 'none'; return; }
         heroPanel.style.display = 'block'; invPanel.style.display = 'block';
         heroName.textContent = h.heroName + ' (' + h.heroClass + ')';
         heroHP.textContent = `HP ${h.hp | 0}/${h.maxHp | 0}`;
@@ -176,7 +175,7 @@ function drawWeather(dt) {
           hero.maxHp *= 1.2; hero.hp = hero.maxHp;
           hero.dps *= 1.2;
           hero.baseSpeed *= 1.2; hero.speed = hero.baseSpeed;
-          hero.regen *= 1.2; hero.mpRegen *= 1.2; hero.attackRange *= 1.2;
+          hero.regen *= 1.2; hero.mpRegen *= 1.2; if (hero.heroClass !== 'paladin') hero.attackRange *= 1.2;
         }
         if (hero.owner === 0) setHeroUI(hero);
       }
@@ -333,7 +332,7 @@ function drawWeather(dt) {
         if (b.kind === 'barracks') { add('Мечник (🍚60/💧24)', () => b.queue.push('soldier')); }
         if (b.kind === 'mBarracks') { add('Маг (🍚80/💧46)', () => b.queue.push('mage')); }
         if (b.kind === 'range') { add('Лучник (🍚70/💧36)', () => b.queue.push('archer')); }
-        if (b.kind === 'altar') { add('Возродить героя', () => { const P = players[0]; if (!P.hero || P.hero.dead) { setTimeout(() => spawnHero(0, b.x + 40, b.y - 20, P.chosenClass), 20000); } }); }
+        if (b.kind === 'altar') { add('Возродить героя', () => { const P = players[0]; if ((!P.hero || P.hero.dead) && !b.queue.includes('hero')) { b.queue.push('hero'); } }); }
       }
       function renderWorkerBuildPanel() {
         const selected = players[0].units.filter(u => u.selected && u.type === 'worker'); if (selected.length === 0) { workerBuild.style.display = 'none'; workerBuild.innerHTML = ''; return; } workerBuild.style.display = 'flex'; workerBuild.innerHTML = '';
@@ -363,7 +362,8 @@ function drawWeather(dt) {
               abilityDesc.textContent = 'Маг: наносит урон с расстояния и поддерживает союзников.';
             }
           } else if (e instanceof Structure) {
-            t = 'Здание: ' + e.kind;
+            const names = { square: 'Площадь' };
+            t = 'Здание: ' + (names[e.kind] || e.kind);
             extra = `HP: ${(e.hp | 0)}/${(e.maxHp | 0)}\nOwner: ${owner}`;
           } else {
             t = 'Нейтрал';
@@ -398,7 +398,7 @@ function drawWeather(dt) {
       }
 
       /* ==== Utils ==== */
-Object.assign(globalThis, { players, neutral, drops, projectiles, riceNodes, waterNodes, COSTS, POP_CAP, resUI, updateRes, placeGhost, trainUnit, renderWorkerBuildPanel, updateBuildingPanel, resumeWorkers, statsPanel, updateStatsPanel, drawMinimap, allUnits, allStructures, nearestNode, lootFromTier, getById, enemiesFor, Unit, Structure, ResourceNode, ItemDrop, NeutralCreep, Projectile, input, setHeroUI });
+      Object.assign(globalThis, { players, neutral, drops, projectiles, riceNodes, waterNodes, COSTS, POP_CAP, resUI, updateRes, placeGhost, trainUnit, renderWorkerBuildPanel, updateBuildingPanel, resumeWorkers, statsPanel, updateStatsPanel, drawMinimap, allUnits, allStructures, nearestNode, lootFromTier, getById, enemiesFor, Unit, Structure, ResourceNode, ItemDrop, NeutralCreep, Projectile, input, setHeroUI, spawnHero });
 
       await import("./ui.js");
 await import("./terrain.js");
@@ -416,6 +416,7 @@ await import("./ai.js");
         const pos = [{ x: 900, y: 900 }, { x: world.width - 1200, y: 1200 }, { x: world.width - 1800, y: world.height - 1400 }];
         const playerClass = await chooseHeroClass();
         for (let i = 0; i < 3; i++) {
+          players[i].startX = pos[i].x; players[i].startY = pos[i].y;
           const HQ = new Structure(pos[i].x, pos[i].y, i, 'hq', false); players[i].structures.push(HQ);
           for (let k = 0; k < 6; k++) { const w = new Unit(HQ.x + (k % 3) * 24, HQ.y + 60 + Math.floor(k / 3) * 24, i, 'worker'); players[i].units.push(w); w.role = (k % 2 === 0) ? 'rice' : 'water'; }
           const cls = (i === 0 ? playerClass : (Math.random() < 0.34 ? 'paladin' : (Math.random() < 0.67 ? 'rogue' : 'archmage')));


### PR DESCRIPTION
## Summary
- Render all units as capsule-style shapes with faction bands, shadows, and selection rings
- Keep hero abilities visible when selecting multiple units and prevent Paladin from gaining ranged attacks
- Queue hero revival and show build progress bars in structures, including altar; AI rebuilds HQ as "Площадь"

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cf8be3a008327b388d6f536a72822