### PR TITLE
refactor: inject dependencies for AI and units

### DIFF
--- a/src/ai.js
+++ b/src/ai.js
@@ -25,14 +25,16 @@ function aiInitPlan(P) {
     nextBuild: 0,
   };
 }
-function aiThink(dt, id) {
-  const players = globalThis.players;
-  const COSTS = globalThis.COSTS;
-  const POP_CAP = globalThis.POP_CAP;
-  const placeGhost = globalThis.placeGhost;
-  const isBlocked = globalThis.isBlocked;
-  const neutral = globalThis.neutral;
-  const dist2 = globalThis.dist2;
+function aiThink(dt, id, deps) {
+  const {
+    players,
+    COSTS,
+    POP_CAP,
+    placeGhost,
+    isBlocked,
+    neutral,
+    dist2,
+  } = deps;
   if (!players[id].ai) return;
   if (!players[id].aiPlan) aiInitPlan(players[id]);
   const P = players[id];
@@ -115,11 +117,9 @@ function aiThink(dt, id) {
 }
 function nearestNeutralCamp(P, neutral, dist2) {
   if (!P.structures.length) {
-    console.warn('nearestNeutralCamp: no structures available');
     return null;
   }
   if (!neutral || !Array.isArray(neutral.units) || neutral.units.length === 0) {
-    console.warn('nearestNeutralCamp: no neutral units');
     return null;
   }
   const origin = P.structures[0];

--- a/src/entities.js
+++ b/src/entities.js
@@ -1,16 +1,16 @@
 /* ==== Entities ==== */
 let nextId = 1;
 
-function moveEntity(e, dx, dy, v, dt) {
+function moveEntity(e, dx, dy, v, dt, isBlocked = globalThis.isBlocked) {
   const d = Math.hypot(dx, dy);
   if (d <= 0) return;
   const nx = e.x + (dx / d) * v * dt, ny = e.y + (dy / d) * v * dt;
-  if (!globalThis.isBlocked(nx, ny)) { e.x = nx; e.y = ny; return; }
+  if (!isBlocked(nx, ny)) { e.x = nx; e.y = ny; return; }
   const ux = -dy / d, uy = dx / d;
   const sx = e.x + ux * v * dt, sy = e.y + uy * v * dt;
-  if (!globalThis.isBlocked(sx, sy)) { e.x = sx; e.y = sy; return; }
+  if (!isBlocked(sx, sy)) { e.x = sx; e.y = sy; return; }
   const sx2 = e.x - ux * v * dt, sy2 = e.y - uy * v * dt;
-  if (!globalThis.isBlocked(sx2, sy2)) { e.x = sx2; e.y = sy2; }
+  if (!isBlocked(sx2, sy2)) { e.x = sx2; e.y = sy2; }
 }
 
 export class Entity {
@@ -46,8 +46,13 @@ export class Entity {
 }
 
 export class Unit extends Entity {
-  constructor(x, y, owner, type = 'worker') {
+  constructor(x, y, owner, type = 'worker', deps = {}) {
     super(x, y, owner);
+    this.deps = {
+      isBlocked: deps.isBlocked || globalThis.isBlocked || (() => false),
+      rand: deps.rand || globalThis.rand || Math.random,
+      players: deps.players || globalThis.players || [],
+    };
     this.type = type;
     this.radius = 12;
     this.speed = 150;
@@ -103,7 +108,7 @@ export class Unit extends Entity {
   }
   updateWorker(dt) {
     if (this.role !== 'rice' && this.role !== 'water') return;
-    const P = globalThis.players[this.owner];
+    const P = this.deps.players[this.owner];
     const HQ = P.structures.find(s => s.kind === 'hq' || s.kind === 'square');
     if (!HQ) { this.state = 'idle'; this.noteTimer = 2; return; }
     const node = (this.role === 'rice' ? nearestNode('rice', P) : nearestNode('water', P));
@@ -111,19 +116,19 @@ export class Unit extends Entity {
     if (this.nodeId !== node.id && this.state !== 'to_hq') {
       this.nodeId = node.id;
       this.state = 'to_node';
-      this.destX = node.x + globalThis.rand(-24, 24);
-      this.destY = node.y + globalThis.rand(-24, 24);
+      this.destX = node.x + this.deps.rand(-24, 24);
+      this.destY = node.y + this.deps.rand(-24, 24);
     }
     if (this.state === 'idle') {
       this.state = 'to_node';
-      this.destX = node.x + globalThis.rand(-24, 24);
-      this.destY = node.y + globalThis.rand(-24, 24);
+      this.destX = node.x + this.deps.rand(-24, 24);
+      this.destY = node.y + this.deps.rand(-24, 24);
     }
     if (this.state === 'to_node') {
       const dx = this.destX - this.x, dy = this.destY - this.y, d = Math.hypot(dx, dy);
       if (d > 2) {
         const v = this.getCurrentSpeed();
-        moveEntity(this, dx, dy, v, dt);
+        moveEntity(this, dx, dy, v, dt, this.deps.isBlocked);
       } else {
         this.state = 'harvest';
         this.workTimer = (this.role === 'rice' ? 2.2 : 2.6);
@@ -134,15 +139,15 @@ export class Unit extends Entity {
       if (this.workTimer <= 0) {
         this.carry = (this.role === 'rice' ? 12 : 9);
         this.state = 'to_hq';
-        this.destX = HQ.x + globalThis.rand(-32, 32);
-        this.destY = HQ.y + globalThis.rand(-32, 32);
+        this.destX = HQ.x + this.deps.rand(-32, 32);
+        this.destY = HQ.y + this.deps.rand(-32, 32);
       }
     }
     if (this.state === 'to_hq') {
       const dx = this.destX - this.x, dy = this.destY - this.y, d = Math.hypot(dx, dy);
       if (d > 2) {
         const v = this.getCurrentSpeed();
-        moveEntity(this, dx, dy, v, dt);
+        moveEntity(this, dx, dy, v, dt, this.deps.isBlocked);
       } else {
         if (this.carry > 0) {
           if (this.role === 'rice') P.res.rice += this.carry;
@@ -151,14 +156,14 @@ export class Unit extends Entity {
           this.carry = 0;
         }
         this.state = 'to_node';
-        this.destX = node.x + globalThis.rand(-24, 24);
-        this.destY = node.y + globalThis.rand(-24, 24);
+        this.destX = node.x + this.deps.rand(-24, 24);
+        this.destY = node.y + this.deps.rand(-24, 24);
       }
     }
   }
   updateRetreat(dt) {
     if (this.owner !== 0 && !this.isHero) {
-      const HQ = globalThis.players[this.owner].structures.find(s => s.kind === 'hq' || s.kind === 'square');
+      const HQ = this.deps.players[this.owner].structures.find(s => s.kind === 'hq' || s.kind === 'square');
       if (this.hp / this.maxHp < 0.35) {
         this.retreat = true;
         if (HQ) this.setDest(HQ.x, HQ.y + 40);
@@ -172,7 +177,7 @@ export class Unit extends Entity {
     const d = Math.hypot(dx, dy);
     if (d > this.attackRange) {
       const v = this.getCurrentSpeed();
-      moveEntity(this, dx, dy, v, dt);
+        moveEntity(this, dx, dy, v, dt, this.deps.isBlocked);
     } else {
       this.attackCd -= dt;
       if (this.attackCd <= 0) {
@@ -191,7 +196,7 @@ export class Unit extends Entity {
     const d = Math.hypot(dx, dy);
     if (d > 2) {
       const v = this.getCurrentSpeed();
-      moveEntity(this, dx, dy, v, dt);
+      moveEntity(this, dx, dy, v, dt, this.deps.isBlocked);
     }
   }
   update(dt) {
@@ -230,7 +235,7 @@ export class Unit extends Entity {
       if (!target || !target.isGhost) { this.state = 'idle'; this.buildTargetId = null; }
       else {
         const dx = target.x - this.x, dy = target.y - this.y, d = Math.hypot(dx, dy);
-        if (d > 40) { const v = this.getCurrentSpeed(); moveEntity(this, dx, dy, v, dt); }
+        if (d > 40) { const v = this.getCurrentSpeed(); moveEntity(this, dx, dy, v, dt, this.deps.isBlocked); }
         else { target.hp += 30 * dt; if (target.hp >= target.maxHp) { target.isGhost = false; target.hp = 520; target.maxHp = 520; this.state = 'idle'; this.buildTargetId = null; if (typeof globalThis.beep === 'function' && !globalThis.muted) globalThis.beep(300, 0.08, 'triangle', 0.05); } }
       }
       return;

--- a/src/main.js
+++ b/src/main.js
@@ -137,13 +137,21 @@ function drawWeather(dt) {
         if (players[owner].units.filter(u => !u.dead && !u.isHero).length >= POP_CAP) { if (owner === 0) playSfx('denied'); return false; }
         const cost = unitType === 'soldier' ? { rice: 60, water: 24 } : unitType === 'mage' ? { rice: 80, water: 46 } : unitType === 'archer' ? { rice: 70, water: 36 } : unitType === 'worker' ? { rice: 50, water: 12 } : { rice: 0, water: 0 };
         const R = players[owner].res; if (R.rice < cost.rice || R.water < cost.water) { if (owner === 0) playSfx('denied'); return false; } R.rice -= cost.rice; if (owner === 0) updateRes();
-        const u = new Unit(barr.x + 36, barr.y, owner, unitType);
+        const u = new Unit(barr.x + 36, barr.y, owner, unitType, getUnitDeps());
         if (unitType === 'soldier') { u.dps = 30; u.maxHp = 160; u.hp = 160; u.attackRange = 30; u.regen = 0.35; }
         if (unitType === 'archer') { u.dps = 20; u.maxHp = 120; u.hp = 120; u.attackRange = 250; u.vision = 520; u.regen = 0.25; }
         if (unitType === 'mage') { u.dps = 22; u.maxHp = 110; u.hp = 110; u.attackRange = 210; u.regen = 0.25; }
         players[owner].units.push(u);
         if (!muted) beep(520, 0.06, 'sawtooth', 0.04);
         return true;
+      }
+
+      function getDeps() {
+        return { players, COSTS, POP_CAP, placeGhost, isBlocked, neutral, dist2 };
+      }
+
+      function getUnitDeps() {
+        return { isBlocked, rand, players };
       }
 
       /* ==== Hero & abilities ==== */
@@ -182,7 +190,7 @@ function drawWeather(dt) {
       }
       ab1.onclick = () => tryCast(1); ab2.onclick = () => tryCast(2); ab3.onclick = () => tryCast(3);
       function spawnHero(owner, x, y, cls = null) {
-        const h = new Unit(x, y, owner, 'soldier'); h.isHero = true; h.maxHp = 420; h.hp = 420; h.maxMp = 160; h.mp = 120; h.dps = 50; h.attackRange = 40; h.vision = 560; h.inventory = []; h.level = 1; h.exp = 0; h.expToNext = 100; h.regen = 0.83; h.mpRegen = 0.8;
+        const h = new Unit(x, y, owner, 'soldier', getUnitDeps()); h.isHero = true; h.maxHp = 420; h.hp = 420; h.maxMp = 160; h.mp = 120; h.dps = 50; h.attackRange = 40; h.vision = 560; h.inventory = []; h.level = 1; h.exp = 0; h.expToNext = 100; h.regen = 0.83; h.mpRegen = 0.8;
         if (!cls) { const r = Math.random(); cls = r < 0.34 ? 'paladin' : (r < 0.67 ? 'rogue' : 'archmage'); }
         h.heroClass = cls; players[owner].chosenClass = cls;
         if (cls === 'paladin') { h.heroName = 'Паладин'; h.cdM1 = 8; h.cdM2 = 12; h.cdM3 = 16; }
@@ -301,13 +309,13 @@ function drawWeather(dt) {
         if (slot === 2 && h.cd2 <= 0) {
           if (h.heroClass === 'paladin') { if (h.mp < 35) return; h.mp -= 35; h.shield = (h.shield || 0) + 120; beep(280, 0.08, 'triangle', 0.05); }
           else if (h.heroClass === 'rogue') { if (h.mp < 40) return; h.mp -= 40; const R = 180; for (const e of players[1].units.concat(players[2].units, neutral.units)) { if (e.dead) continue; if (Math.hypot(e.x - h.x, e.y - h.y) <= R) { e.damage(70, 0); } } beep(720, 0.08, 'square', 0.06); }
-          else { if (h.mp < 60) return; h.mp -= 60; const e = new Unit(h.x + 24, h.y, h.owner, 'elemental'); e.dps = 18; e.maxHp = 200; e.hp = 200; e.attackRange = 210; e.summonTimer = 20; players[h.owner].units.push(e); beep(480, 0.09, 'sawtooth', 0.06); }
+          else { if (h.mp < 60) return; h.mp -= 60; const e = new Unit(h.x + 24, h.y, h.owner, 'elemental', getUnitDeps()); e.dps = 18; e.maxHp = 200; e.hp = 200; e.attackRange = 210; e.summonTimer = 20; players[h.owner].units.push(e); beep(480, 0.09, 'sawtooth', 0.06); }
           h.cd2 = h.cdM2; if (h.owner === 0) setHeroUI(h);
         }
         if (slot === 3 && h.cd3 <= 0) {
           if (h.heroClass === 'paladin') { if (h.mp < 45) return; h.mp -= 45; const R = 200; for (const u of players[0].units) { if (Math.hypot(u.x - h.x, u.y - h.y) <= R) u.hp = Math.min(u.maxHp, u.hp + 70); } for (const e of players[1].units.concat(players[2].units, neutral.units)) { if (Math.hypot(e.x - h.x, e.y - h.y) <= R) e.damage(60, 0); } beep(560, 0.09, 'triangle', 0.06); }
           else if (h.heroClass === 'rogue') { if (h.mp < 55) return; h.mp -= 55; const R = 220; for (const e of players[1].units.concat(players[2].units, neutral.units)) { if (Math.hypot(e.x - h.x, e.y - h.y) <= R) { e.damage(50, 0); e.slow = 3.5; } } beep(900, 0.07, 'square', 0.06); }
-          else { if (h.mp < 90) return; h.mp -= 90; const d = new Unit(h.x + 28, h.y + 12, h.owner, 'demon'); d.dps = 36; d.maxHp = 500; d.hp = 500; d.attackRange = 60; d.summonTimer = 25; players[h.owner].units.push(d); beep(360, 0.12, 'sawtooth', 0.07); }
+          else { if (h.mp < 90) return; h.mp -= 90; const d = new Unit(h.x + 28, h.y + 12, h.owner, 'demon', getUnitDeps()); d.dps = 36; d.maxHp = 500; d.hp = 500; d.attackRange = 60; d.summonTimer = 25; players[h.owner].units.push(d); beep(360, 0.12, 'sawtooth', 0.07); }
           h.cd3 = h.cdM3; if (h.owner === 0) setHeroUI(h);
         }
       }
@@ -529,7 +537,7 @@ await import("./ai.js");
         for (let i = 0; i < 3; i++) {
           players[i].startX = pos[i].x; players[i].startY = pos[i].y;
           const HQ = new Structure(pos[i].x, pos[i].y, i, 'hq', false); players[i].structures.push(HQ);
-          for (let k = 0; k < 6; k++) { const w = new Unit(HQ.x + (k % 3) * 24, HQ.y + 60 + Math.floor(k / 3) * 24, i, 'worker'); players[i].units.push(w); w.role = (k % 2 === 0) ? 'rice' : 'water'; }
+          for (let k = 0; k < 6; k++) { const w = new Unit(HQ.x + (k % 3) * 24, HQ.y + 60 + Math.floor(k / 3) * 24, i, 'worker', getUnitDeps()); players[i].units.push(w); w.role = (k % 2 === 0) ? 'rice' : 'water'; }
           const cls = (i === 0 ? playerClass : (Math.random() < 0.34 ? 'paladin' : (Math.random() < 0.67 ? 'rogue' : 'archmage')));
           spawnHero(i, HQ.x + 80, HQ.y - 20, cls);
           riceNodes.push(new ResourceNode(HQ.x + 220, HQ.y + 160, 'rice')); waterNodes.push(new ResourceNode(HQ.x - 220, HQ.y + 160, 'water'));
@@ -581,7 +589,7 @@ globalThis.drawHp = drawHp;
         clearVisible(); for (const s of players[0].structures) revealCircle(s.x, s.y, 520); for (const u of players[0].units) revealCircle(u.x, u.y, 480);
         if (!globalThis.paused) {
           const sp = 900 / world.zoom; if (input.keys['w'] || input.keys['ц']) world.camY -= sp * dt; if (input.keys['s'] || input.keys['ы']) world.camY += sp * dt; if (input.keys['a'] || input.keys['ф']) world.camX -= sp * dt; if (input.keys['d'] || input.keys['в']) world.camX += sp * dt; clampCam();
-          for (const p of players) { for (const s of p.structures) s.update(dt); for (const u of p.units) u.update(dt); if (p.ai) aiThink(dt, players.indexOf(p)); }
+          for (const p of players) { for (const s of p.structures) s.update(dt); for (const u of p.units) u.update(dt); if (p.ai) aiThink(dt, players.indexOf(p), getDeps()); }
           for (const n of neutral.units) { n.update(dt); if (n.dead && !n.awarded) { if (n.lastHitBy != null && n.lastHitBy >= 0) { heroGainFromNeutral(n.lastHitBy, n.tier); }
             if (n.group && n.group.dropsLeft > 0) { drops.push(new ItemDrop(n.x, n.y, lootFromTier(n.tier))); n.group.dropsLeft--; }
             n.awarded = true; } }

--- a/test/ai.test.js
+++ b/test/ai.test.js
@@ -1,5 +1,5 @@
 const assert = require('assert');
-const { nearestNeutralCamp } = require('../src/ai.js');
+const { nearestNeutralCamp, aiThink } = require('../src/ai.js');
 
 const dist2 = (x1, y1, x2, y2) => (x1 - x2) ** 2 + (y1 - y2) ** 2;
 
@@ -43,6 +43,32 @@ const dist2 = (x1, y1, x2, y2) => (x1 - x2) ** 2 + (y1 - y2) ** 2;
   const P = { structures: [{ x: 0, y: 0 }] };
   const result = nearestNeutralCamp(P, neutral, dist2);
   assert.strictEqual(result, null);
+})();
+
+// aiThink works with injected dependencies
+(() => {
+  const players = [
+    { units: [], structures: [], hero: null, ai: false },
+    {
+      units: [],
+      structures: [{ kind: 'square', queue: [] }],
+      hero: null,
+      ai: true,
+      aiPlan: { open: [], nextBuild: 0, comp: { soldier: 0, archer: 0, mage: 0 }, pushAt: 10 },
+      res: { rice: 100, water: 100 },
+    },
+  ];
+  const deps = {
+    players,
+    COSTS: {},
+    POP_CAP: 10,
+    placeGhost: () => false,
+    isBlocked: () => false,
+    neutral: { units: [] },
+    dist2,
+  };
+  aiThink(0, 1, deps);
+  assert.ok(players[1].structures[0].queue.includes('worker'));
 })();
 
 console.log('All tests passed.');

--- a/test/mp-regen.test.js
+++ b/test/mp-regen.test.js
@@ -7,6 +7,8 @@ global.enemiesFor = () => [];
 global.dist2 = () => 0;
 global.players = [];
 global.neutral = { units: [] };
+global.riceNodes = [{ id: 1, x: 10, y: 0 }];
+global.waterNodes = [];
 
 // mp regenerates up to max
 (() => {
@@ -29,3 +31,23 @@ global.neutral = { units: [] };
 })();
 
 console.log('MP regen tests passed.');
+
+// Unit.updateWorker uses injected deps
+(() => {
+  global.rand = () => { throw new Error('global rand used'); };
+  const fakeRand = () => 0;
+  let blocked = 0;
+  const isBlocked = () => { blocked++; return false; };
+  const players = [
+    null,
+    { structures: [{ kind: 'square', x: 0, y: 0 }], res: { rice: 0, water: 0 } },
+  ];
+  const u = new Unit(0, 0, 1, 'worker', { rand: fakeRand, isBlocked, players });
+  u.role = 'rice';
+  u.state = 'idle';
+  u.updateWorker(0.1); // sets destination
+  u.updateWorker(1);   // moves and calls isBlocked
+  assert.strictEqual(u.destX, 10);
+  assert.strictEqual(u.destY, 0);
+  assert.ok(blocked > 0);
+})();


### PR DESCRIPTION
## Summary
- inject dependencies into `aiThink` and `nearestNeutralCamp`
- refactor entities to accept `isBlocked`, `rand`, and `players` via deps
- pass dependency objects through game bootstrap and add tests for DI

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689e1e320198832797ccf204da8facff