### PR TITLE
Add behavior tree AI with difficulty levels

### DIFF
--- a/src/ai.js
+++ b/src/ai.js
@@ -1,144 +1,225 @@
-/* ==== AI ==== */
-function aiInitPlan(P) {
-  const cls = P.hero && P.hero.heroClass;
-  const plans = {
-    paladin: {
-      comp: { soldier: 0.6, archer: 0.4, mage: 0.0 },
-      open: ['well', 'barracks', 'range'],
-      state: 'farm',
-      pushAt: 10,
-      nextBuild: 0,
-    },
-    rogue: {
-      comp: { soldier: 0.4, archer: 0.6, mage: 0.0 },
-      open: ['well', 'range', 'barracks'],
-      state: 'farm',
-      pushAt: 8,
-      nextBuild: 0,
-    },
-  };
-  P.aiPlan = plans[cls] || {
-    comp: { soldier: 0.2, archer: 0.4, mage: 0.4 },
-    open: ['well', 'mBarracks', 'range'],
+/* ==== AI Controller ==== */
+const { Selector, Sequence, Action } = require('./ai/behavior.js');
+
+const DIFFICULTY_CONFIG = {
+  easy: {
+    comp: { soldier: 0.5, archer: 0.5, mage: 0.0 },
+    open: ['well', 'barracks'],
+    pushAt: 8,
+    aggression: 0.5,
+    buildInterval: 20,
+  },
+  normal: {
+    comp: { soldier: 0.4, archer: 0.4, mage: 0.2 },
+    open: ['well', 'barracks', 'range'],
+    pushAt: 10,
+    aggression: 0.7,
+    buildInterval: 15,
+  },
+  hard: {
+    comp: { soldier: 0.3, archer: 0.4, mage: 0.3 },
+    open: ['well', 'barracks', 'range', 'mBarracks'],
+    pushAt: 8,
+    aggression: 1.0,
+    buildInterval: 10,
+  },
+};
+
+function aiInitPlan(P, level = 'normal') {
+  const cfg = DIFFICULTY_CONFIG[level] || DIFFICULTY_CONFIG.normal;
+  P.aiPlan = {
+    comp: { ...cfg.comp },
+    open: [...cfg.open],
     state: 'farm',
-    pushAt: 12,
+    pushAt: cfg.pushAt,
     nextBuild: 0,
+    aggression: cfg.aggression,
+    buildInterval: cfg.buildInterval,
   };
 }
-function aiThink(dt, id, deps) {
-  const {
-    players,
-    COSTS,
-    POP_CAP,
-    placeGhost,
-    isBlocked,
-    neutral,
-    dist2,
-  } = deps;
-  if (!players[id].ai) return;
-  if (!players[id].aiPlan) aiInitPlan(players[id]);
-  const P = players[id];
-  let HQ = P.structures.find(s => s.kind === 'hq' || s.kind === 'square');
-  if (!HQ) {
-    const cost = COSTS.square;
-    const px = P.startX || 0, py = P.startY || 0;
-    if (P.res.rice >= cost.rice && P.res.water >= cost.water && !isBlocked(px, py) && placeGhost(id, px, py, 'square')) {
-      const g = P.structures.find(s => s.isGhost && s.kind === 'square');
-      const w = P.units.find(u => u.type === 'worker');
-      if (g && w) { w.state = 'build'; w.buildTargetId = g.id; }
-    }
-    HQ = P.structures.find(s => s.kind === 'square');
+
+class AIController {
+  constructor(id, deps) {
+    this.id = id;
+    this.deps = deps;
+    this.player = deps.players[id];
+    this.level = 'normal';
+    this.behavior = null;
   }
-  // buildings
-  if (P.aiPlan.nextBuild < P.aiPlan.open.length && HQ) {
-    const kind = P.aiPlan.open[P.aiPlan.nextBuild]; const cost = COSTS[kind];
-    if (P.res.rice >= cost.rice && P.res.water >= cost.water) {
-      const dx = (kind === 'well') ? -160 : (Math.random() < 0.5 ? 180 : -180), dy = (kind === 'well') ? 120 : (Math.random() < 0.5 ? 160 : -160);
-      const px = HQ.x + dx, py = HQ.y + dy; if (!isBlocked(px, py) && placeGhost(id, px, py, kind)) { P.aiPlan.nextBuild++; const g = P.structures.find(s => s.isGhost && s.kind === kind && Math.hypot(s.x - px, s.y - py) < 10); const w = P.units.find(u => u.type === 'worker'); if (g && w) { w.state = 'build'; w.buildTargetId = g.id; } }
-    }
+  setDifficulty(level) {
+    this.level = level;
   }
-  // maintain 6 workers
-  const wcount = P.units.filter(u => u.type === 'worker').length;
-  if (wcount < 6 && HQ) {
-    if (P.res.rice >= 50 && P.res.water >= 12 && P.units.filter(u => !u.dead && !u.isHero).length < POP_CAP) { HQ.queue.push('worker'); }
+  init() {
+    aiInitPlan(this.player, this.level);
+    this.buildBehaviorTree();
   }
-  // training
-  const barr = P.structures.find(s => s.kind === 'barracks' && !s.isGhost),
-        rng = P.structures.find(s => s.kind === 'range' && !s.isGhost),
-        mb = P.structures.find(s => s.kind === 'mBarracks' && !s.isGhost);
-  if (P.units.filter(u => !u.dead && !u.isHero).length < POP_CAP - 1) {
-    const r = Math.random();
-    if (barr && r < P.aiPlan.comp.soldier) barr.queue.push('soldier');
-    else if (rng && r < P.aiPlan.comp.soldier + P.aiPlan.comp.archer) rng.queue.push('archer');
-    else if (mb) mb.queue.push('mage');
+  buildBehaviorTree() {
+    this.behavior = new Sequence([
+      new Action(() => { this.ensureHQ(); return true; }),
+      new Action(() => { this.buildOpenings(); return true; }),
+      new Action(() => { this.maintainWorkers(); return true; }),
+      new Action(() => { this.trainUnits(); return true; }),
+      new Action(() => { this.heroActions(); return true; }),
+      new Action(() => { this.earlyArmyFarm(); return true; }),
+      new Action(() => { this.engage(); return true; }),
+      new Action(() => { this.rallyAttack(); return true; }),
+      new Action(() => { this.completeGhosts(); return true; }),
+    ]);
   }
-  // hero farms neutrals only with support
-  const army = P.units.filter(u => u.type !== 'worker' && !u.isHero);
-  const hero = P.hero;
-  if (hero && !hero.dead) {
-    if (army.length >= 2 && hero.hp > hero.maxHp * 0.6) {
-      const tgt = nearestNeutralCamp(P, neutral, dist2);
-      if (tgt) { hero.setTarget(tgt); }
-    }
-    if (hero.targetId) {
-      const idx = hero.inventory.findIndex(it => it.startsWith('scroll_'));
-      if (idx >= 0) { globalThis.applyItem(hero, hero.inventory[idx]); hero.inventory.splice(idx, 1); }
-    }
+  think(dt) {
+    if (!this.player.ai) return;
+    if (!this.behavior || !this.player.aiPlan) this.init();
+    this.behavior.tick({ dt, controller: this });
   }
-  // early army neutral farming
-  if (army.length >= 3 && army.length < P.aiPlan.pushAt) {
-    const nt = nearestNeutralCamp(P, neutral, dist2);
-    if (nt) { army.forEach(u => { if (!u.retreat) u.setTarget(nt); }); }
-  }
-  // нападение при преимуществе
-  const enemyUnits = players[0].units.filter(u => !u.dead);
-  for (const u of army) {
-    const seen = enemyUnits.filter(e => Math.hypot(e.x - u.x, e.y - u.y) < u.vision);
-    if (seen.length) {
-      const enemyCount = seen.length;
-      const myCount = army.filter(a => Math.hypot(a.x - u.x, a.y - u.y) < u.vision).length;
-      if (myCount > enemyCount) {
-        army.forEach(a => { if (!a.retreat) a.setTarget(seen[0]); });
+
+  // Actions derived from original aiThink
+  ensureHQ() {
+    const P = this.player;
+    const { COSTS, placeGhost, isBlocked } = this.deps;
+    let HQ = P.structures.find(s => s.kind === 'hq' || s.kind === 'square');
+    if (!HQ) {
+      const cost = COSTS.square;
+      const px = P.startX || 0, py = P.startY || 0;
+      if (P.res.rice >= cost.rice && P.res.water >= cost.water && !isBlocked(px, py) && placeGhost(this.id, px, py, 'square')) {
+        const g = P.structures.find(s => s.isGhost && s.kind === 'square');
+        const w = P.units.find(u => u.type === 'worker');
+        if (g && w) { w.state = 'build'; w.buildTargetId = g.id; }
       }
-      break;
     }
   }
-  // army rally / attack
-  if (army.length >= P.aiPlan.pushAt) {
-    const enemyHero = players[0].hero && !players[0].hero.dead ? players[0].hero : null;
-    const tgt = enemyHero || players[0].structures.find(s => !s.isGhost) || players[0].units.find(u => !u.isHero);
-    if (tgt) { army.forEach(u => { if (!u.retreat) u.setTarget(tgt); }); }
+
+  buildOpenings() {
+    const P = this.player;
+    const { COSTS, placeGhost, isBlocked } = this.deps;
+    const HQ = P.structures.find(s => s.kind === 'hq' || s.kind === 'square');
+    if (P.aiPlan.nextBuild < P.aiPlan.open.length && HQ) {
+      const kind = P.aiPlan.open[P.aiPlan.nextBuild];
+      const cost = COSTS[kind];
+      if (P.res.rice >= cost.rice && P.res.water >= cost.water) {
+        const dx = (kind === 'well') ? -160 : (Math.random() < 0.5 ? 180 : -180);
+        const dy = (kind === 'well') ? 120 : (Math.random() < 0.5 ? 160 : -160);
+        const px = HQ.x + dx, py = HQ.y + dy;
+        if (!isBlocked(px, py) && placeGhost(this.id, px, py, kind)) {
+          P.aiPlan.nextBuild++;
+          const g = P.structures.find(s => s.isGhost && s.kind === kind && Math.hypot(s.x - px, s.y - py) < 10);
+          const w = P.units.find(u => u.type === 'worker');
+          if (g && w) { w.state = 'build'; w.buildTargetId = g.id; }
+        }
+      }
+    }
   }
-  const ghost = P.structures.find(s => s.isGhost);
-  if (ghost) {
-    const w = P.units.find(u => u.type === 'worker' && u.state !== 'build');
-    if (w) { w.state = 'build'; w.buildTargetId = ghost.id; }
+
+  maintainWorkers() {
+    const P = this.player;
+    const { POP_CAP } = this.deps;
+    const HQ = P.structures.find(s => s.kind === 'hq' || s.kind === 'square');
+    const wcount = P.units.filter(u => u.type === 'worker').length;
+    if (wcount < 6 && HQ) {
+      if (P.res.rice >= 50 && P.res.water >= 12 && P.units.filter(u => !u.dead && !u.isHero).length < POP_CAP) {
+        HQ.queue.push('worker');
+      }
+    }
+  }
+
+  trainUnits() {
+    const P = this.player;
+    const { POP_CAP } = this.deps;
+    const barr = P.structures.find(s => s.kind === 'barracks' && !s.isGhost),
+      rng = P.structures.find(s => s.kind === 'range' && !s.isGhost),
+      mb = P.structures.find(s => s.kind === 'mBarracks' && !s.isGhost);
+    if (P.units.filter(u => !u.dead && !u.isHero).length < POP_CAP - 1) {
+      const r = Math.random();
+      if (barr && r < P.aiPlan.comp.soldier) barr.queue.push('soldier');
+      else if (rng && r < P.aiPlan.comp.soldier + P.aiPlan.comp.archer) rng.queue.push('archer');
+      else if (mb) mb.queue.push('mage');
+    }
+  }
+
+  heroActions() {
+    const P = this.player;
+    const { neutral, dist2 } = this.deps;
+    const army = P.units.filter(u => u.type !== 'worker' && !u.isHero);
+    const hero = P.hero;
+    if (hero && !hero.dead) {
+      if (army.length >= 2 && hero.hp > hero.maxHp * 0.6) {
+        const tgt = nearestNeutralCamp(P, neutral, dist2);
+        if (tgt) { hero.setTarget(tgt); }
+      }
+      if (hero.targetId) {
+        const idx = hero.inventory.findIndex(it => it.startsWith('scroll_'));
+        if (idx >= 0) {
+          if (globalThis.applyItem) globalThis.applyItem(hero, hero.inventory[idx]);
+          hero.inventory.splice(idx, 1);
+        }
+      }
+    }
+  }
+
+  earlyArmyFarm() {
+    const P = this.player;
+    const { neutral, dist2 } = this.deps;
+    const army = P.units.filter(u => u.type !== 'worker' && !u.isHero);
+    if (army.length >= 3 && army.length < P.aiPlan.pushAt) {
+      const nt = nearestNeutralCamp(P, neutral, dist2);
+      if (nt) { army.forEach(u => { if (!u.retreat) u.setTarget(nt); }); }
+    }
+  }
+
+  engage() {
+    const P = this.player;
+    const { players } = this.deps;
+    const army = P.units.filter(u => u.type !== 'worker' && !u.isHero);
+    const enemyUnits = players[0].units.filter(u => !u.dead);
+    for (const u of army) {
+      const seen = enemyUnits.filter(e => Math.hypot(e.x - u.x, e.y - u.y) < u.vision);
+      if (seen.length) {
+        const enemyCount = seen.length;
+        const myCount = army.filter(a => Math.hypot(a.x - u.x, a.y - u.y) < u.vision).length;
+        if (myCount > enemyCount) {
+          army.forEach(a => { if (!a.retreat) a.setTarget(seen[0]); });
+        }
+        break;
+      }
+    }
+  }
+
+  rallyAttack() {
+    const P = this.player;
+    const { players } = this.deps;
+    const army = P.units.filter(u => u.type !== 'worker' && !u.isHero);
+    if (army.length >= P.aiPlan.pushAt) {
+      const enemyHero = players[0].hero && !players[0].hero.dead ? players[0].hero : null;
+      const tgt = enemyHero || players[0].structures.find(s => !s.isGhost) || players[0].units.find(u => !u.isHero);
+      if (tgt) { army.forEach(u => { if (!u.retreat) u.setTarget(tgt); }); }
+    }
+  }
+
+  completeGhosts() {
+    const P = this.player;
+    const ghost = P.structures.find(s => s.isGhost);
+    if (ghost) {
+      const w = P.units.find(u => u.type === 'worker' && u.state !== 'build');
+      if (w) { w.state = 'build'; w.buildTargetId = ghost.id; }
+    }
   }
 }
+
 function nearestNeutralCamp(P, neutral, dist2) {
-  if (!P.structures.length) {
-    return null;
-  }
-  if (!neutral || !Array.isArray(neutral.units) || neutral.units.length === 0) {
-    return null;
-  }
+  if (!P.structures.length) return null;
+  if (!neutral || !Array.isArray(neutral.units) || neutral.units.length === 0) return null;
   const origin = P.structures[0];
   let best = null;
   let bestDist = Infinity;
   for (const n of neutral.units) {
     if (n.dead) continue;
     const d = dist2(origin.x, origin.y, n.x, n.y);
-    if (d < bestDist) {
-      bestDist = d;
-      best = n;
-    }
+    if (d < bestDist) { bestDist = d; best = n; }
   }
   return best;
 }
-  if (typeof module !== 'undefined' && module.exports) {
-    // Node.js/TEST environment
-    module.exports = { aiInitPlan, aiThink, nearestNeutralCamp };
-  } else {
-    // Browser environment - expose to global scope
-    Object.assign(globalThis, { aiInitPlan, aiThink, nearestNeutralCamp });
-  }
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { AIController, aiInitPlan, nearestNeutralCamp, DIFFICULTY_CONFIG };
+} else {
+  Object.assign(globalThis, { AIController, aiInitPlan, nearestNeutralCamp, DIFFICULTY_CONFIG });
+}

--- a/src/ai/behavior.js
+++ b/src/ai/behavior.js
@@ -1,0 +1,38 @@
+class Selector {
+  constructor(children = []) {
+    this.children = children;
+  }
+  tick(ctx) {
+    for (const child of this.children) {
+      if (child.tick(ctx)) return true;
+    }
+    return false;
+  }
+}
+
+class Sequence {
+  constructor(children = []) {
+    this.children = children;
+  }
+  tick(ctx) {
+    for (const child of this.children) {
+      if (!child.tick(ctx)) return false;
+    }
+    return true;
+  }
+}
+
+class Action {
+  constructor(fn) {
+    this.fn = fn;
+  }
+  tick(ctx) {
+    return this.fn(ctx);
+  }
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { Selector, Sequence, Action };
+} else {
+  Object.assign(globalThis, { Selector, Sequence, Action });
+}

--- a/src/main.js
+++ b/src/main.js
@@ -93,8 +93,8 @@ function drawWeather(dt) {
       /* ==== Players & economy ==== */
       const players = [
         { name: 'Игрок', color: '#6bb0ff', res: { rice: 220, water: 100 }, units: [], structures: [], hero: null, ai: false, aiPlan: null },
-        { name: 'AI‑1', color: '#e05dff', res: { rice: 220, water: 100 }, units: [], structures: [], hero: null, ai: true, aiPlan: null },
-        { name: 'AI‑2', color: '#ffd27a', res: { rice: 220, water: 100 }, units: [], structures: [], hero: null, ai: true, aiPlan: null }
+        { name: 'AI‑1', color: '#e05dff', res: { rice: 220, water: 100 }, units: [], structures: [], hero: null, ai: true, aiPlan: null, difficulty: 'easy', controller: null },
+        { name: 'AI‑2', color: '#ffd27a', res: { rice: 220, water: 100 }, units: [], structures: [], hero: null, ai: true, aiPlan: null, difficulty: 'hard', controller: null }
       ];
       const riceNodes = [], waterNodes = [];
       const resUI = { rice: document.getElementById('resRice'), water: document.getElementById('resWater'), pop: document.getElementById('pop'), idle: document.getElementById('idleWorkers') };
@@ -153,6 +153,8 @@ function drawWeather(dt) {
       function getUnitDeps() {
         return { isBlocked, rand, players };
       }
+
+      const deps = getDeps();
 
       /* ==== Hero & abilities ==== */
       const heroPanel = document.getElementById('heroPanel'); const abilityDesc = document.getElementById('abilityDesc');
@@ -589,7 +591,18 @@ globalThis.drawHp = drawHp;
         clearVisible(); for (const s of players[0].structures) revealCircle(s.x, s.y, 520); for (const u of players[0].units) revealCircle(u.x, u.y, 480);
         if (!globalThis.paused) {
           const sp = 900 / world.zoom; if (input.keys['w'] || input.keys['ц']) world.camY -= sp * dt; if (input.keys['s'] || input.keys['ы']) world.camY += sp * dt; if (input.keys['a'] || input.keys['ф']) world.camX -= sp * dt; if (input.keys['d'] || input.keys['в']) world.camX += sp * dt; clampCam();
-          for (const p of players) { for (const s of p.structures) s.update(dt); for (const u of p.units) u.update(dt); if (p.ai) aiThink(dt, players.indexOf(p), getDeps()); }
+          for (const p of players) {
+            for (const s of p.structures) s.update(dt);
+            for (const u of p.units) u.update(dt);
+            if (p.ai) {
+              if (!p.controller) {
+                p.controller = new AIController(players.indexOf(p), deps);
+                p.controller.setDifficulty(p.difficulty || 'normal');
+                p.controller.init();
+              }
+              p.controller.think(dt);
+            }
+          }
           for (const n of neutral.units) { n.update(dt); if (n.dead && !n.awarded) { if (n.lastHitBy != null && n.lastHitBy >= 0) { heroGainFromNeutral(n.lastHitBy, n.tier); }
             if (n.group && n.group.dropsLeft > 0) { drops.push(new ItemDrop(n.x, n.y, lootFromTier(n.tier))); n.group.dropsLeft--; }
             n.awarded = true; } }

--- a/test/ai.test.js
+++ b/test/ai.test.js
@@ -1,9 +1,9 @@
 const assert = require('assert');
-const { nearestNeutralCamp, aiThink } = require('../src/ai.js');
+const { AIController, nearestNeutralCamp, DIFFICULTY_CONFIG } = require('../src/ai.js');
 
 const dist2 = (x1, y1, x2, y2) => (x1 - x2) ** 2 + (y1 - y2) ** 2;
 
-// no structures
+// nearestNeutralCamp tests remain
 (() => {
   const neutral = { units: [] };
   const P = { structures: [] };
@@ -11,7 +11,6 @@ const dist2 = (x1, y1, x2, y2) => (x1 - x2) ** 2 + (y1 - y2) ** 2;
   assert.strictEqual(result, null);
 })();
 
-// no neutral units
 (() => {
   const neutral = { units: [] };
   const P = { structures: [{ x: 0, y: 0 }] };
@@ -19,7 +18,6 @@ const dist2 = (x1, y1, x2, y2) => (x1 - x2) ** 2 + (y1 - y2) ** 2;
   assert.strictEqual(result, null);
 })();
 
-// chooses nearest
 (() => {
   const neutral = {
     units: [
@@ -32,7 +30,6 @@ const dist2 = (x1, y1, x2, y2) => (x1 - x2) ** 2 + (y1 - y2) ** 2;
   assert.ok(result === neutral.units[1]);
 })();
 
-// all neutral camps dead
 (() => {
   const neutral = {
     units: [
@@ -45,8 +42,8 @@ const dist2 = (x1, y1, x2, y2) => (x1 - x2) ** 2 + (y1 - y2) ** 2;
   assert.strictEqual(result, null);
 })();
 
-// aiThink works with injected dependencies
-(() => {
+// AIController initialization and behavior for each difficulty
+['easy', 'normal', 'hard'].forEach(level => {
   const players = [
     { units: [], structures: [], hero: null, ai: false },
     {
@@ -54,21 +51,25 @@ const dist2 = (x1, y1, x2, y2) => (x1 - x2) ** 2 + (y1 - y2) ** 2;
       structures: [{ kind: 'square', queue: [] }],
       hero: null,
       ai: true,
-      aiPlan: { open: [], nextBuild: 0, comp: { soldier: 0, archer: 0, mage: 0 }, pushAt: 10 },
+      aiPlan: null,
       res: { rice: 100, water: 100 },
     },
   ];
   const deps = {
     players,
-    COSTS: {},
+    COSTS: { square: { rice: 0, water: 0 }, well: { rice: 0, water: 0 }, barracks: { rice: 0, water: 0 }, range: { rice: 0, water: 0 }, mBarracks: { rice: 0, water: 0 } },
     POP_CAP: 10,
     placeGhost: () => false,
     isBlocked: () => false,
     neutral: { units: [] },
     dist2,
   };
-  aiThink(0, 1, deps);
+  const controller = new AIController(1, deps);
+  controller.setDifficulty(level);
+  controller.init();
+  assert.strictEqual(players[1].aiPlan.pushAt, DIFFICULTY_CONFIG[level].pushAt);
+  controller.think(0);
   assert.ok(players[1].structures[0].queue.includes('worker'));
-})();
+});
 
 console.log('All tests passed.');


### PR DESCRIPTION
## Summary
- Implement AIController interface and behavior tree nodes
- Add difficulty configuration and behavior-based AI logic
- Update game loop to instantiate AI controllers with difficulty
- Cover AI controller behavior with unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689e21b88b148327b8490245f657e259