### PR TITLE
fix: support browser env for AI controller

### DIFF
--- a/src/ai.js
+++ b/src/ai.js
@@ -1,5 +1,15 @@
 /* ==== AI Controller ==== */
-const { Selector, Sequence, Action } = require('./ai/behavior.js');
+// Support both Node (tests) and browser environments. In Node we use
+// `require` while in the browser the behavior classes are exposed on
+// `globalThis` by `behavior.js` which is imported separately.
+let Selector, Sequence, Action;
+if (typeof require !== 'undefined') {
+  // Node/CommonJS path used in tests
+  ({ Selector, Sequence, Action } = require('./ai/behavior.js'));
+} else {
+  // Browser path – behavior.js attaches classes to globalThis
+  ({ Selector, Sequence, Action } = globalThis);
+}
 
 const DIFFICULTY_CONFIG = {
   easy: {

--- a/src/main.js
+++ b/src/main.js
@@ -539,6 +539,9 @@ function drawWeather(dt) {
       await import("./ui.js");
 await import("./terrain.js");
 await import("./fog.js");
+// `ai.js` depends on `behavior.js` attaching symbols to `globalThis` in the
+// browser, so ensure it is loaded before the controller itself.
+await import("./ai/behavior.js");
 await import("./ai.js");
 
 /* ==== Setup/Reset ==== */


### PR DESCRIPTION
## Summary
- Avoid Node-only `require` in `ai.js` by falling back to globals in the browser
- Load behavior helpers before AI controller to ensure availability in browsers

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e2b611c6c832788f6bb5a398ea095