### PR TITLE
feat: convert modules and add fire aura scroll

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "my-html-page",
   "version": "1.0.0",
   "description": "A simple static HTML page project.",
+  "type": "module",
   "main": "index.js",
   "scripts": {
     "test": "node test/ai.test.js && node test/mp-regen.test.js"

--- a/src/ai.js
+++ b/src/ai.js
@@ -1,15 +1,5 @@
 /* ==== AI Controller ==== */
-// Support both Node (tests) and browser environments. In Node we use
-// `require` while in the browser the behavior classes are exposed on
-// `globalThis` by `behavior.js` which is imported separately.
-let Selector, Sequence, Action;
-if (typeof require !== 'undefined') {
-  // Node/CommonJS path used in tests
-  ({ Selector, Sequence, Action } = require('./ai/behavior.js'));
-} else {
-  // Browser path – behavior.js attaches classes to globalThis
-  ({ Selector, Sequence, Action } = globalThis);
-}
+import { Selector, Sequence, Action } from './ai/behavior.js';
 
 const DIFFICULTY_CONFIG = {
   easy: {
@@ -350,8 +340,5 @@ function nearestNeutralCamp(P, neutral, dist2) {
   return best;
 }
 
-if (typeof module !== 'undefined' && module.exports) {
-  module.exports = { AIController, aiInitPlan, nearestNeutralCamp, DIFFICULTY_CONFIG };
-} else {
-  Object.assign(globalThis, { AIController, aiInitPlan, nearestNeutralCamp, DIFFICULTY_CONFIG });
-}
+export { AIController, aiInitPlan, nearestNeutralCamp, DIFFICULTY_CONFIG };
+Object.assign(globalThis, { AIController, aiInitPlan, nearestNeutralCamp, DIFFICULTY_CONFIG });

--- a/src/ai/behavior.js
+++ b/src/ai/behavior.js
@@ -1,4 +1,4 @@
-class Selector {
+export class Selector {
   constructor(children = []) {
     this.children = children;
   }
@@ -10,7 +10,7 @@ class Selector {
   }
 }
 
-class Sequence {
+export class Sequence {
   constructor(children = []) {
     this.children = children;
   }
@@ -22,7 +22,7 @@ class Sequence {
   }
 }
 
-class Action {
+export class Action {
   constructor(fn) {
     this.fn = fn;
   }
@@ -31,8 +31,5 @@ class Action {
   }
 }
 
-if (typeof module !== 'undefined' && module.exports) {
-  module.exports = { Selector, Sequence, Action };
-} else {
-  Object.assign(globalThis, { Selector, Sequence, Action });
-}
+// Expose for browser without bundler
+Object.assign(globalThis, { Selector, Sequence, Action });

--- a/src/config/ai.js
+++ b/src/config/ai.js
@@ -1,0 +1,9 @@
+export const DEBUG_AI = false;
+
+export function packPower(units) {
+  let p = 0;
+  for (const u of units) {
+    p += (u.hp * 0.5 + u.dps * 12) * (u.ranged ? 1.05 : 1) * (u.armor ? 1.05 : 1);
+  }
+  return p;
+}

--- a/src/config/visual.js
+++ b/src/config/visual.js
@@ -1,0 +1,2 @@
+export const WATER = { waveSpeed: 0.06, waveAmp: 2.0, rippleScale: 0.25, borderColor: 'rgba(255,255,255,0.6)' };
+export const RICE  = { patternSeed: 7, borderColor: 'rgba(255,230,120,0.8)' };

--- a/src/effects/FireAuraEffect.js
+++ b/src/effects/FireAuraEffect.js
@@ -1,0 +1,44 @@
+export class FireAuraEffect {
+  constructor({ radius, dpsPerTick, tickMs, durationMs }) {
+    this.radius = radius;
+    this.dpsPerTick = dpsPerTick;
+    this.tickMs = tickMs;
+    this.durationMs = durationMs;
+    this.elapsed = 0;
+    this.tickTimer = 0;
+    this.done = false;
+  }
+  update(dt, host) {
+    if (this.done) return;
+    this.elapsed += dt * 1000;
+    this.tickTimer += dt * 1000;
+    if (this.tickTimer >= this.tickMs) {
+      this.tickTimer -= this.tickMs;
+      const enemies = globalThis.enemiesFor(host.owner) || [];
+      const r2 = this.radius * this.radius;
+      for (const e of enemies) {
+        if (e.dead) continue;
+        if (globalThis.dist2(host.x, host.y, e.x, e.y) <= r2) {
+          e.damage(this.dpsPerTick, host.owner);
+        }
+      }
+    }
+    if (this.elapsed >= this.durationMs || host.dead) {
+      this.done = true;
+    }
+  }
+  draw(ctx, host) {
+    const s = globalThis.worldToScreen(host.x, host.y);
+    const zoom = globalThis.world.zoom;
+    const pulse = this.radius + Math.sin(Date.now() * 0.005) * 5;
+    ctx.save();
+    ctx.strokeStyle = 'rgba(255,80,0,0.35)';
+    ctx.lineWidth = 2;
+    ctx.beginPath();
+    ctx.arc(s.x, s.y, pulse * zoom, 0, Math.PI * 2);
+    ctx.stroke();
+    ctx.restore();
+  }
+}
+
+Object.assign(globalThis, { FireAuraEffect });

--- a/src/entities.js
+++ b/src/entities.js
@@ -87,11 +87,10 @@ export class Unit extends Entity {
     this.retreat = false;
     this.regen = 0.25;
     this.auraTimer = 0;
-    this.fireAura = 0;
-    this.fireAuraTick = 0;
     this.buildTargetId = null;
     this.noteTimer = 0;
     this.nodeId = null;
+    this.effects = [];
   }
   setDest(x, y) {
     this.destX = x;
@@ -208,20 +207,10 @@ export class Unit extends Entity {
       this.mp = Math.min(this.maxMp, this.mp + this.mpRegen * dt * 60);
     }
     if (this.auraTimer > 0) { this.auraTimer = Math.max(0, this.auraTimer - dt); }
-    if (this.fireAura > 0) {
-      this.fireAura = Math.max(0, this.fireAura - dt);
-      this.fireAuraTick -= dt;
-      if (this.fireAuraTick <= 0) {
-        this.fireAuraTick = 1;
-        const R = 100;
-        const enemies = enemiesFor(this.owner);
-        for (const e of enemies) {
-          if (e.dead) continue;
-          if (globalThis.dist2(this.x, this.y, e.x, e.y) <= R * R) {
-            e.damage(25, this.owner);
-          }
-        }
-      }
+    for (let i = this.effects.length - 1; i >= 0; i--) {
+      const eff = this.effects[i];
+      eff.update(dt, this);
+      if (eff.done) this.effects.splice(i, 1);
     }
     this.cd1 = Math.max(0, this.cd1 - dt);
     this.cd2 = Math.max(0, this.cd2 - dt);
@@ -317,12 +306,8 @@ export class Unit extends Entity {
     }
     ctx.restore();
     globalThis.drawHp(s.x, s.y - 18 * zoom, this.hp / this.maxHp);
-    if (this.fireAura > 0) {
-      ctx.strokeStyle = 'rgba(255,80,0,0.35)';
-      const pulse = 100 + Math.sin(Date.now() / 200) * 5;
-      ctx.beginPath();
-      ctx.arc(s.x, s.y, pulse * zoom, 0, 6.283);
-      ctx.stroke();
+    for (const eff of this.effects) {
+      if (eff.draw) eff.draw(ctx, this);
     }
     if (this.auraTimer > 0) {
       ctx.strokeStyle = 'rgba(255,215,0,0.5)';
@@ -515,7 +500,7 @@ export class ItemDrop extends Entity {
     const colors = {
       scroll_hp: '#7cff97',
       scroll_dps: '#ffd27a',
-      scroll_fire: '#ff7a4d',
+      scroll_fire_aura: '#ff7a4d',
       ring_atk: '#8ad',
       boots: '#8ad',
       amulet: '#8ad',
@@ -722,7 +707,7 @@ export function nearestNode(type, P) {
 }
 
 export function lootFromTier(t) {
-  const base = ['scroll_hp', 'scroll_dps', 'scroll_fire'];
+  const base = ['scroll_hp', 'scroll_dps', 'scroll_fire_aura'];
   const rare = ['ring_atk', 'boots', 'amulet', 'orb'];
   return (Math.random() < 0.6 ? base[(Math.random() * base.length) | 0] : rare[(Math.random() * rare.length) | 0]);
 }

--- a/src/items/catalog.js
+++ b/src/items/catalog.js
@@ -1,0 +1,11 @@
+import { FireAuraEffect } from '../effects/FireAuraEffect.js';
+
+export const ITEMS = {
+  scroll_fire_aura: {
+    kind: 'scroll',
+    spriteFrame: 'scroll_fire',
+    use(hero) {
+      hero.effects.push(new FireAuraEffect({ radius: 100, dpsPerTick: 10, tickMs: 1000, durationMs: 20000 }));
+    }
+  }
+};

--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,6 @@
 import { drawSprite } from "./sprites.js";
 import { Unit, Structure, ResourceNode, ItemDrop, NeutralCreep, Projectile, getById, enemiesFor, allUnits, allStructures, nearestNode, lootFromTier } from "./entities.js";
+import { FireAuraEffect } from "./effects/FireAuraEffect.js";
 
 /* ==== Helpers ==== */
 const clamp = (v, a, b) => Math.max(a, Math.min(b, v));
@@ -251,7 +252,7 @@ function drawWeather(dt) {
       const itemInfo = {
         scroll_hp: { name: 'Свиток HP', desc: '+120 HP и +80 макс HP', rarity: 'Обычный' },
         scroll_dps: { name: 'Свиток DPS', desc: '+10 DPS на 20с', rarity: 'Обычный' },
-        scroll_fire: { name: 'Свиток ауры огня', desc: 'Огненная аура 20с, 25 урона/с в радиусе 100', rarity: 'Обычный' },
+        scroll_fire_aura: { name: 'Свиток ауры огня', desc: 'Огненная аура 20с, 10 урона/с в радиусе 100', rarity: 'Обычный' },
         ring_atk: { name: 'Кольцо маны', desc: '+40 MP', rarity: 'Редкий' },
         boots: { name: 'Сапоги', desc: '+20 скорость', rarity: 'Редкий' },
         amulet: { name: 'Амулет', desc: '+120 HP', rarity: 'Редкий' },
@@ -260,7 +261,7 @@ function drawWeather(dt) {
       const itemColors = {
         scroll_hp: '#7cff97',
         scroll_dps: '#ffd27a',
-        scroll_fire: '#ff7a4d',
+        scroll_fire_aura: '#ff7a4d',
         ring_atk: '#8ad',
         boots: '#8ad',
         amulet: '#8ad',
@@ -301,9 +302,10 @@ function drawWeather(dt) {
           if (remove) return;
           hero.dps += 10; hero.auraTimer = 20; if (typeof beep === 'function' && !muted) beep(720, 0.08, 'square', 0.06);
           setTimeout(() => { hero.dps -= 10; }, 20000);
-        } else if (itemKind === 'scroll_fire') {
+        } else if (itemKind === 'scroll_fire_aura') {
           if (remove) return;
-          hero.fireAura = 20; hero.fireAuraTick = 0; if (typeof beep === 'function' && !muted) beep(640, 0.08, 'sawtooth', 0.06);
+          hero.effects.push(new FireAuraEffect({ radius: 100, dpsPerTick: 10, tickMs: 1000, durationMs: 20000 }));
+          if (typeof beep === 'function' && !muted) beep(640, 0.08, 'sawtooth', 0.06);
         } else if (itemKind === 'ring_atk') {
           hero.maxMp += 40 * sign; hero.mp += 40 * sign; if (!remove && typeof beep === 'function' && !muted) beep(540, 0.08, 'sawtooth', 0.05);
         } else if (itemKind === 'boots') {
@@ -498,7 +500,7 @@ function drawWeather(dt) {
             extra = `HP: ${(e.hp | 0)}/${(e.maxHp | 0)}\nOwner: ${owner}`;
           } else {
             t = e.displayName || 'Нейтрал';
-            const names = { scroll_hp: 'Свиток HP', scroll_dps: 'Свиток DPS', scroll_fire: 'Свиток ауры огня', ring_atk: 'Кольцо маны', boots: 'Сапоги', amulet: 'Амулет', orb: 'Орб маны' };
+            const names = { scroll_hp: 'Свиток HP', scroll_dps: 'Свиток DPS', scroll_fire_aura: 'Свиток ауры огня', ring_atk: 'Кольцо маны', boots: 'Сапоги', amulet: 'Амулет', orb: 'Орб маны' };
             let loot = '';
             if (e.lootTable) {
               loot = e.lootTable.map(l => `${names[l.item] || l.item} (${Math.round(l.chance * 100)}%)`).join(', ');

--- a/src/terrain.js
+++ b/src/terrain.js
@@ -1,4 +1,5 @@
 import { drawSprite } from './sprites.js';
+import { WATER, RICE } from './config/visual.js';
 
 /* ==== Terrain generation and blockers ==== */
 const blockers = []; // {x,y,r,kind}
@@ -14,7 +15,11 @@ const waterTile = document.createElement('canvas');
 waterTile.width = TILE; waterTile.height = TILE;
 const wctx = waterTile.getContext('2d');
 wctx.imageSmoothingEnabled = false;
-drawSprite(wctx, 'water', TILE / 2, TILE / 2, { scale: 4 });
+const grad = wctx.createLinearGradient(0, 0, 0, TILE);
+grad.addColorStop(0, '#1e5799');
+grad.addColorStop(1, '#08304b');
+wctx.fillStyle = grad;
+wctx.fillRect(0, 0, TILE, TILE);
 
 const treeBase = document.createElement('canvas');
 treeBase.width = 16; treeBase.height = 16;
@@ -63,7 +68,18 @@ export function drawTerrain() {
       const size = step * world.zoom;
       ctx.drawImage(grassTile, dx, dy, size, size);
       const tx = Math.floor(x / step), ty = Math.floor(y / step);
-      if ((hash(tx, ty) & 255) < 10) ctx.drawImage(waterTile, dx, dy, size, size);
+      if ((hash(tx, ty) & 255) < 10) {
+        ctx.drawImage(waterTile, dx, dy, size, size);
+        const t = (globalThis.simTime || 0) * WATER.waveSpeed;
+        ctx.save();
+        ctx.globalAlpha = 0.2;
+        ctx.fillStyle = '#fff';
+        for (let i = 0; i < size; i += 8) {
+          const ry = Math.sin((i / size + t) * Math.PI * 2) * WATER.waveAmp;
+          ctx.fillRect(dx + i, dy + size / 2 + ry, 8, WATER.rippleScale * size);
+        }
+        ctx.restore();
+      }
     }
   }
 }

--- a/test/ai.test.js
+++ b/test/ai.test.js
@@ -1,5 +1,5 @@
-const assert = require('assert');
-const { AIController, nearestNeutralCamp, DIFFICULTY_CONFIG } = require('../src/ai.js');
+import assert from 'assert';
+import { AIController, nearestNeutralCamp, DIFFICULTY_CONFIG } from '../src/ai.js';
 
 const dist2 = (x1, y1, x2, y2) => (x1 - x2) ** 2 + (y1 - y2) ** 2;
 

--- a/test/mp-regen.test.js
+++ b/test/mp-regen.test.js
@@ -1,14 +1,14 @@
-const assert = require('assert');
-const { Unit } = require('../src/entities.js');
+import assert from 'assert';
+import { Unit } from '../src/entities.js';
 
-global.isBlocked = () => false;
-global.getById = () => null;
-global.enemiesFor = () => [];
-global.dist2 = () => 0;
-global.players = [];
-global.neutral = { units: [] };
-global.riceNodes = [{ id: 1, x: 10, y: 0 }];
-global.waterNodes = [];
+globalThis.isBlocked = () => false;
+globalThis.getById = () => null;
+globalThis.enemiesFor = () => [];
+globalThis.dist2 = () => 0;
+globalThis.players = [];
+globalThis.neutral = { units: [] };
+globalThis.riceNodes = [{ id: 1, x: 10, y: 0 }];
+globalThis.waterNodes = [];
 
 // mp regenerates up to max
 (() => {
@@ -34,7 +34,7 @@ console.log('MP regen tests passed.');
 
 // Unit.updateWorker uses injected deps
 (() => {
-  global.rand = () => { throw new Error('global rand used'); };
+  globalThis.rand = () => { throw new Error('global rand used'); };
   const fakeRand = () => 0;
   let blocked = 0;
   const isBlocked = () => { blocked++; return false; };


### PR DESCRIPTION
## Summary
- migrate AI utilities to ES modules and expose globally
- add configurable fire aura effect and scroll
- refresh terrain water rendering with simple ripple

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e3130274c8327af88b7b2e3e0a490