### PR TITLE
Handle AI action failures with boolean results

### DIFF
--- a/src/ai.js
+++ b/src/ai.js
@@ -66,22 +66,22 @@ class AIController {
   }
   buildBehaviorTree() {
     this.behavior = new Sequence([
-      new Action(() => { this.ensureHQ(); return true; }),
-      new Action(({ dt }) => { this.buildOpenings(dt); return true; }),
-      new Action(() => { this.maintainWorkers(); return true; }),
-      new Action(() => { this.redistributeWorkers(); return true; }),
-      new Action(({ dt }) => { this.trainUnits(dt); return true; }),
-      new Action(() => { this.heroActions(); return true; }),
-      new Action(() => { this.earlyArmyFarm(); return true; }),
-      new Action(({ dt }) => { this.adaptiveRecon(dt); return true; }),
-      new Action(() => { this.defendBase(); return true; }),
-      new Action(() => { this.coordinateWithAlly(); return true; }),
-      new Action(() => { this.prepareFinalPush(); return true; }),
-      new Action(() => { this.skirmish(); return true; }),
-      new Action(() => { this.engage(); return true; }),
-      new Action(() => { this.rallyAttack(); return true; }),
-      new Action(() => { this.completeGhosts(); return true; }),
-      new Action(() => { this.updateLearning(); return true; }),
+      new Action(this.ensureHQ.bind(this)),
+      new Action(this.buildOpenings.bind(this)),
+      new Action(this.maintainWorkers.bind(this)),
+      new Action(this.redistributeWorkers.bind(this)),
+      new Action(this.trainUnits.bind(this)),
+      new Action(this.heroActions.bind(this)),
+      new Action(this.earlyArmyFarm.bind(this)),
+      new Action(this.adaptiveRecon.bind(this)),
+      new Action(this.defendBase.bind(this)),
+      new Action(this.coordinateWithAlly.bind(this)),
+      new Action(this.prepareFinalPush.bind(this)),
+      new Action(this.skirmish.bind(this)),
+      new Action(this.engage.bind(this)),
+      new Action(this.rallyAttack.bind(this)),
+      new Action(this.completeGhosts.bind(this)),
+      new Action(this.updateLearning.bind(this)),
     ]);
   }
   think(dt) {
@@ -98,35 +98,36 @@ class AIController {
   ensureHQ() {
     const P = this.player;
     const { COSTS, placeGhost, isBlocked } = this.deps;
-    let HQ = P.structures.find(s => s.kind === 'hq' || s.kind === 'square');
-    if (!HQ) {
-      const cost = COSTS.square;
-      const px = P.startX || 0, py = P.startY || 0;
-      if (P.res.rice >= cost.rice && P.res.water >= cost.water && !isBlocked(px, py) && placeGhost(this.id, px, py, 'square')) {
-        const g = P.structures.find(s => s.isGhost && s.kind === 'square');
-        const w = P.units.find(u => u.type === 'worker');
-        if (g && w) { w.state = 'build'; w.buildTargetId = g.id; }
-      }
+    const HQ = P.structures.find(s => s.kind === 'hq' || s.kind === 'square');
+    if (HQ) return true;
+    const cost = COSTS.square;
+    const px = P.startX || 0, py = P.startY || 0;
+    if (P.res.rice >= cost.rice && P.res.water >= cost.water && !isBlocked(px, py) && placeGhost(this.id, px, py, 'square')) {
+      const g = P.structures.find(s => s.isGhost && s.kind === 'square');
+      const w = P.units.find(u => u.type === 'worker');
+      if (g && w) { w.state = 'build'; w.buildTargetId = g.id; }
+      return true;
     }
+    return false;
   }
 
-  buildOpenings(dt = 0) {
+  buildOpenings({ dt = 0 } = {}) {
     const P = this.player;
     const { COSTS, placeGhost, isBlocked } = this.deps;
     P.aiPlan.buildTimer -= dt;
-    if (P.aiPlan.buildTimer > 0) return;
+    if (P.aiPlan.buildTimer > 0) return true;
     const HQ = P.structures.find(s => s.kind === 'hq' || s.kind === 'square');
     if (P.aiPlan.nextBuild < P.aiPlan.open.length && HQ) {
       const worker = P.units.find(u => u.type === 'worker' && u.state !== 'build');
       if (!worker) {
         this.maintainWorkers();
         P.aiPlan.buildTimer = 1 + Math.random();
-        return;
+        return false;
       }
       const kind = P.aiPlan.open[P.aiPlan.nextBuild];
       if (P.structures.some(s => s.kind === kind && !s.isGhost)) {
         P.aiPlan.nextBuild++;
-        return;
+        return true;
       }
       const cost = COSTS[kind];
       if (P.res.rice >= cost.rice && P.res.water >= cost.water) {
@@ -153,28 +154,35 @@ class AIController {
             worker.state = 'build';
             worker.buildTargetId = g.id;
           }
-        } else {
-          P.aiPlan.buildFailCount++;
-          P.aiPlan.buildSearchRadius += 40;
-          if (P.aiPlan.buildFailCount >= 5) {
-            if (DEBUG_AI) console.log('build fail skip', kind);
-            P.aiPlan.buildFailCount = 0;
-            P.aiPlan.nextBuild++;
-          }
-          P.aiPlan.buildTimer = 1;
+          return true;
         }
+        P.aiPlan.buildFailCount++;
+        P.aiPlan.buildSearchRadius += 40;
+        if (P.aiPlan.buildFailCount >= 5) {
+          if (DEBUG_AI) console.log('build fail skip', kind);
+          P.aiPlan.buildFailCount = 0;
+          P.aiPlan.nextBuild++;
+        }
+        P.aiPlan.buildTimer = 1;
+        return false;
       }
+      return false;
     }
+    return true;
   }
 
   maintainWorkers() {
     const P = this.player;
     const { POP_CAP } = this.deps;
     const HQ = P.structures.find(s => s.kind === 'hq' || s.kind === 'square');
+    if (!HQ) return false;
+    let success = true;
     const wcount = P.units.filter(u => u.type === 'worker').length;
-    if (wcount < 6 && HQ) {
+    if (wcount < 6) {
       if (P.res.rice >= 50 && P.res.water >= 12 && P.units.filter(u => !u.dead && !u.isHero).length < POP_CAP) {
         HQ.queue.push('worker');
+      } else {
+        success = false;
       }
     }
     const unassigned = P.units.filter(u => u.type === 'worker' && (u.role === null || u.role === undefined));
@@ -183,12 +191,13 @@ class AIController {
       worker.role = resType;
       worker.state = 'idle';
     }
+    return success;
   }
 
   // Scenario 3: flexible distribution of workers between resources
   redistributeWorkers() {
     const P = this.player;
-    if (!P.units) return;
+    if (!P.units) return false;
     const riceWorkers = P.units.filter(u => u.type === 'worker' && u.role === 'rice');
     const waterWorkers = P.units.filter(u => u.type === 'worker' && u.role === 'water');
     if (P.res.rice < P.res.water && waterWorkers.length > 0) {
@@ -200,47 +209,52 @@ class AIController {
       w.role = 'water';
       w.state = 'idle';
     }
+    return true;
   }
 
-  trainUnits(dt = 0) {
+  trainUnits({ dt = 0 } = {}) {
     const P = this.player;
     const { POP_CAP } = this.deps;
     P.aiPlan.trainCooldown -= dt;
-    if (P.aiPlan.trainCooldown > 0) return;
+    if (P.aiPlan.trainCooldown > 0) return true;
     P.aiPlan.trainCooldown = 0.3 + Math.random() * 0.3;
     const barr = P.structures.find(s => s.kind === 'barracks' && !s.isGhost),
       rng = P.structures.find(s => s.kind === 'range' && !s.isGhost),
       mb = P.structures.find(s => s.kind === 'mBarracks' && !s.isGhost);
     const units = P.units.filter(u => !u.dead && !u.isHero);
-    if (units.length >= POP_CAP) return;
-    if (P.res.rice < P.aiPlan.minReserve.rice || P.res.water < P.aiPlan.minReserve.water) return;
+    if (units.length >= POP_CAP) return false;
+    if (P.res.rice < P.aiPlan.minReserve.rice || P.res.water < P.aiPlan.minReserve.water) return false;
     const count = type => units.filter(u => u.type === type).length +
       (barr && type === 'soldier' ? barr.queue.filter(q => q === 'soldier').length : 0) +
       (rng && type === 'archer' ? rng.queue.filter(q => q === 'archer').length : 0) +
       (mb && type === 'mage' ? mb.queue.filter(q => q === 'mage').length : 0);
     const minComp = { soldier: 3, archer: 2, mage: 1 };
-    if (barr && count('soldier') < minComp.soldier && barr.queue.length < 5) { barr.queue.push('soldier'); return; }
-    if (rng && count('archer') < minComp.archer && rng.queue.length < 5) { rng.queue.push('archer'); return; }
-    if (mb && count('mage') < minComp.mage && mb.queue.length < 5) { mb.queue.push('mage'); return; }
+    if (barr && count('soldier') < minComp.soldier && barr.queue.length < 5) { barr.queue.push('soldier'); return true; }
+    if (rng && count('archer') < minComp.archer && rng.queue.length < 5) { rng.queue.push('archer'); return true; }
+    if (mb && count('mage') < minComp.mage && mb.queue.length < 5) { mb.queue.push('mage'); return true; }
     const r = Math.random();
-    if (barr && r < P.aiPlan.comp.soldier && barr.queue.length < 5) barr.queue.push('soldier');
-    else if (rng && r < P.aiPlan.comp.soldier + P.aiPlan.comp.archer && rng.queue.length < 5) rng.queue.push('archer');
-    else if (mb && mb.queue.length < 5) mb.queue.push('mage');
+    if (barr && r < P.aiPlan.comp.soldier && barr.queue.length < 5) { barr.queue.push('soldier'); return true; }
+    if (rng && r < P.aiPlan.comp.soldier + P.aiPlan.comp.archer && rng.queue.length < 5) { rng.queue.push('archer'); return true; }
+    if (mb && mb.queue.length < 5) { mb.queue.push('mage'); return true; }
+    return false;
   }
 
   // Scenario 2: adaptive reconnaissance using periodic scouting units
-  adaptiveRecon(dt = 0) {
+  adaptiveRecon({ dt = 0 } = {}) {
     const P = this.player;
-    if (!P.aiPlan) return;
+    if (!P.aiPlan) return false;
     P.aiPlan.scoutTimer -= dt;
-    if (P.aiPlan.scoutTimer > 0) return;
+    if (P.aiPlan.scoutTimer > 0) return true;
     const scout = P.units.find(u => u.type !== 'worker' && !u.isHero);
     if (scout && typeof scout.setDest === 'function') {
       const px = (Math.random() - 0.5) * 800;
       const py = (Math.random() - 0.5) * 800;
       scout.setDest(px, py);
+      P.aiPlan.scoutTimer = 300;
+      return true;
     }
     P.aiPlan.scoutTimer = 300; // reset timer
+    return false;
   }
 
   // Scenario 1: base defense mode when resources low or under attack
@@ -248,7 +262,7 @@ class AIController {
     const P = this.player;
     const { players } = this.deps;
     const HQ = P.structures.find(s => s.kind === 'hq' || s.kind === 'square');
-    if (!HQ) return;
+    if (!HQ) return false;
     const enemyUnits = players[0] ? players[0].units.filter(u => !u.dead) : [];
     const threat = enemyUnits.find(e => Math.hypot(e.x - HQ.x, e.y - HQ.y) < 200);
     if (P.res.rice < 50 || P.res.water < 30 || threat) {
@@ -260,30 +274,35 @@ class AIController {
         const w = P.units.find(u => u.type === 'worker' && u.state !== 'build');
         if (w) { w.state = 'build'; w.buildTargetId = damaged.id; }
       }
+      return true;
     }
+    return false;
   }
 
   // Scenario 4: coordinate with allies for combined attacks
   coordinateWithAlly() {
     const { players } = this.deps;
-    if (!players || players.length < 3) return;
+    if (!players || players.length < 3) return false;
     const ally = players[2];
-    if (!ally || !ally.attackTarget) return;
+    if (!ally || !ally.attackTarget) return false;
     const army = this.player.units.filter(u => u.type !== 'worker' && !u.isHero);
     army.forEach(u => { if (typeof u.setTarget === 'function') u.setTarget(ally.attackTarget); });
+    return true;
   }
 
   // Scenario 5: preparation for a final push when resources and army allow
   prepareFinalPush() {
     const P = this.player;
-    if (P.aiPlan.finalPush) return;
+    if (P.aiPlan.finalPush) return true;
     const army = P.units.filter(u => u.type !== 'worker' && !u.isHero);
     if (army.length >= P.aiPlan.pushAt && P.res.rice > 200 && P.res.water > 200) {
       P.aiPlan.finalPush = true;
       P.aiPlan.pushAt = army.length + 5;
       const mb = P.structures.find(s => s.kind === 'mBarracks' && !s.isGhost);
       if (mb) mb.queue.push('mage');
+      return true;
     }
+    return false;
   }
 
   // Scenario 7: hybrid attack-retreat probing enemy defenses
@@ -291,15 +310,16 @@ class AIController {
     const P = this.player;
     const { players } = this.deps;
     const enemy = players[0];
-    if (!enemy) return;
+    if (!enemy) return false;
     const army = P.units.filter(u => u.type !== 'worker' && !u.isHero);
-    if (army.length < 2) return;
+    if (army.length < 2) return false;
     const probe = army.slice(0, Math.min(2, army.length));
     const target = enemy.structures[0] || enemy.units[0];
     if (target) probe.forEach(u => { if (typeof u.setTarget === 'function') u.setTarget(target); });
     if (enemy.units.length > army.length) {
       probe.forEach(u => { if (typeof u.setTarget === 'function') u.setTarget(P.structures[0]); });
     }
+    return true;
   }
 
   // Scenario 6: simple learning mechanism adjusting unit composition
@@ -312,7 +332,7 @@ class AIController {
 
   updateLearning() {
     const P = this.player;
-    if (!P.aiPlan || !P.aiPlan.battleHistory.length) return;
+    if (!P.aiPlan || !P.aiPlan.battleHistory.length) return false;
     const wins = P.aiPlan.battleHistory.filter(Boolean).length;
     const losses = P.aiPlan.battleHistory.length - wins;
     if (losses > wins) {
@@ -320,6 +340,7 @@ class AIController {
       P.aiPlan.comp.soldier = Math.max(0, 1 - P.aiPlan.comp.archer - P.aiPlan.comp.mage);
     }
     P.aiPlan.battleHistory = [];
+    return true;
   }
 
   heroActions() {
@@ -339,27 +360,32 @@ class AIController {
           hero.inventory.splice(idx, 1);
         }
       }
+      return true;
     }
+    return false;
   }
 
   earlyArmyFarm() {
     const P = this.player;
     const { neutral, dist2 } = this.deps;
     const army = P.units.filter(u => u.type !== 'worker' && !u.isHero);
-    if (army.length < 2 || army.length >= P.aiPlan.pushAt) return;
+    if (army.length < 2 || army.length >= P.aiPlan.pushAt) return false;
     const camp = nearestNeutralCamp(P, neutral, dist2);
-    if (!camp) return;
+    if (!camp) return false;
     const ourP = packPower(army);
     const campP = campPower(camp);
     if (ourP >= campP * 1.2) {
       army.forEach(u => { if (!u.retreat) u.setTarget(camp); });
+      return true;
     }
+    return false;
   }
 
   engage() {
     const P = this.player;
     const { players } = this.deps;
     const army = P.units.filter(u => u.type !== 'worker' && !u.isHero);
+    if (!army.length) return false;
     const enemies = players
       .filter((_, i) => i !== this.id)
       .flatMap(pl => pl.units.filter(u => !u.dead));
@@ -370,7 +396,7 @@ class AIController {
         a.retreat = true;
         if (P.structures[0] && typeof a.setTarget === 'function') a.setTarget(P.structures[0]);
       });
-      return;
+      return true;
     }
     for (const u of army) {
       const seen = enemies.filter(e => Math.hypot(e.x - u.x, e.y - u.y) < u.vision);
@@ -379,10 +405,12 @@ class AIController {
         const myCount = army.filter(a => Math.hypot(a.x - u.x, a.y - u.y) < u.vision).length;
         if (myCount > enemyCount) {
           army.forEach(a => { if (!a.retreat) a.setTarget(seen[0]); });
+          return true;
         }
         break;
       }
     }
+    return false;
   }
 
   rallyAttack() {
@@ -403,8 +431,13 @@ class AIController {
         pl.structures.forEach(check);
         pl.units.forEach(u => { if (!u.isHero) check(u); });
       });
-      if (best) army.forEach(u => { if (!u.retreat) u.setTarget(best); });
+      if (best) {
+        army.forEach(u => { if (!u.retreat) u.setTarget(best); });
+        return true;
+      }
+      return false;
     }
+    return false;
   }
 
   completeGhosts() {
@@ -412,8 +445,10 @@ class AIController {
     const ghost = P.structures.find(s => s.isGhost);
     if (ghost) {
       const w = P.units.find(u => u.type === 'worker' && u.state !== 'build');
-      if (w) { w.state = 'build'; w.buildTargetId = ghost.id; }
+      if (w) { w.state = 'build'; w.buildTargetId = ghost.id; return true; }
+      return false;
     }
+    return false;
   }
 }
 

--- a/src/ai/behavior.js
+++ b/src/ai/behavior.js
@@ -4,7 +4,7 @@ export class Selector {
   }
   tick(ctx) {
     for (const child of this.children) {
-      if (child.tick(ctx)) return true;
+      if (child.tick(ctx) === true) return true;
     }
     return false;
   }
@@ -16,7 +16,7 @@ export class Sequence {
   }
   tick(ctx) {
     for (const child of this.children) {
-      if (!child.tick(ctx)) return false;
+      if (child.tick(ctx) === false) return false;
     }
     return true;
   }

--- a/test/ai.test.js
+++ b/test/ai.test.js
@@ -4,6 +4,77 @@ import { packPower, campPower } from '../src/config/ai.js';
 
 const dist2 = (x1, y1, x2, y2) => (x1 - x2) ** 2 + (y1 - y2) ** 2;
 
+// ensureHQ returns false without resources then succeeds
+(() => {
+  const COSTS = { square: { rice: 50, water: 50 } };
+  const players = [
+    { units: [], structures: [], hero: null, ai: false },
+    {
+      units: [{ type: 'worker', state: 'idle' }],
+      structures: [],
+      hero: null,
+      ai: true,
+      aiPlan: null,
+      res: { rice: 0, water: 0 },
+      startX: 0,
+      startY: 0,
+    },
+  ];
+  let placed = false;
+  const deps = {
+    players,
+    COSTS,
+    POP_CAP: 10,
+    placeGhost: () => { placed = true; players[1].structures.push({ kind: 'square', isGhost: true, id: 1, x: 0, y: 0, queue: [] }); return true; },
+    isBlocked: () => false,
+    neutral: { camps: [] },
+    dist2,
+    packPower,
+    campPower,
+  };
+  const ai = new AIController(1, deps);
+  ai.init();
+  assert.strictEqual(ai.ensureHQ(), false);
+  players[1].res.rice = 50; players[1].res.water = 50;
+  assert.strictEqual(ai.ensureHQ(), true);
+  assert.ok(placed);
+})();
+
+// buildOpenings waits for resources and retries next tick
+(() => {
+  const COSTS = { square: { rice: 0, water: 0 }, barracks: { rice: 60, water: 40 } };
+  const events = [];
+  const players = [
+    { units: [], structures: [], hero: null, ai: false },
+    {
+      units: [{ type: 'worker', state: 'idle' }],
+      structures: [{ kind: 'square', x: 0, y: 0, queue: [], id: 1 }],
+      hero: null,
+      ai: true,
+      aiPlan: null,
+      res: { rice: 0, water: 0 },
+    },
+  ];
+  const deps = {
+    players,
+    COSTS,
+    POP_CAP: 10,
+    placeGhost: (id, x, y, kind) => { events.push({ x, y, kind }); players[1].structures.push({ kind, x, y, id: events.length + 1, isGhost: true, queue: [] }); return true; },
+    isBlocked: () => false,
+    neutral: { camps: [] },
+    dist2,
+    packPower,
+    campPower,
+  };
+  const ai = new AIController(1, deps);
+  ai.init();
+  ai.player.aiPlan.open = ['barracks'];
+  assert.strictEqual(ai.buildOpenings({ dt: 0 }), false);
+  players[1].res.rice = 60; players[1].res.water = 40;
+  assert.strictEqual(ai.buildOpenings({ dt: 0 }), true);
+  assert.strictEqual(events[0].kind, 'barracks');
+})();
+
 // buildOpenings places well and barracks with fallback when blocked
 (() => {
   const COSTS = { square: { rice: 0, water: 0 }, well: { rice: 0, water: 0 }, barracks: { rice: 0, water: 0 } };
@@ -36,11 +107,11 @@ const dist2 = (x1, y1, x2, y2) => (x1 - x2) ** 2 + (y1 - y2) ** 2;
   };
   const ai = new AIController(1, deps);
   ai.init();
-  ai.buildOpenings(0); // build well
+  assert.strictEqual(ai.buildOpenings({ dt: 0 }), true); // build well
   players[1].units[0].state = 'idle';
-  ai.buildOpenings(6); // attempt barracks but blocked after timer
-  ai.buildOpenings(1); // cooldown and retry
-  ai.buildOpenings(0); // fallback placement
+  assert.strictEqual(ai.buildOpenings({ dt: 6 }), false); // attempt barracks but blocked after timer
+  assert.strictEqual(ai.buildOpenings({ dt: 1 }), true); // cooldown tick, no attempt
+  assert.strictEqual(ai.buildOpenings({ dt: 0 }), true); // fallback placement
   assert.strictEqual(events[0].kind, 'well');
   assert.strictEqual(events[1].kind, 'barracks');
   assert.ok(Math.abs(events[1].x) > 220);
@@ -65,9 +136,12 @@ const dist2 = (x1, y1, x2, y2) => (x1 - x2) ** 2 + (y1 - y2) ** 2;
   const deps = { players, COSTS, POP_CAP: 10, placeGhost: () => false, isBlocked: () => false, neutral: { camps: [] }, dist2, packPower, campPower };
   const ai = new AIController(1, deps);
   ai.init();
-  ai.trainUnits(1); // soldier to reach minimum
+  players[1].res.rice = 0; players[1].res.water = 0;
+  assert.strictEqual(ai.trainUnits({ dt: 1 }), false);
+  players[1].res.rice = 200; players[1].res.water = 200;
+  assert.strictEqual(ai.trainUnits({ dt: 1 }), true); // soldier to reach minimum
   players[1].units.push({ type: 'soldier' });
-  ai.trainUnits(1); // archer next
+  assert.strictEqual(ai.trainUnits({ dt: 1 }), true); // archer next
   assert.strictEqual(barr.queue[0], 'soldier');
   assert.strictEqual(rng.queue[0], 'archer');
 })();
@@ -93,7 +167,7 @@ const dist2 = (x1, y1, x2, y2) => (x1 - x2) ** 2 + (y1 - y2) ** 2;
   const deps = { players, COSTS: {}, POP_CAP: 10, placeGhost: () => false, isBlocked: () => false, neutral, dist2, packPower, campPower };
   const ai = new AIController(1, deps);
   ai.init();
-  ai.earlyArmyFarm();
+  assert.strictEqual(ai.earlyArmyFarm(), true);
   assert.strictEqual(hero.target, undefined);
   assert.strictEqual(soldier.target, camp);
   assert.strictEqual(archer.target, camp);
@@ -118,9 +192,29 @@ const dist2 = (x1, y1, x2, y2) => (x1 - x2) ** 2 + (y1 - y2) ** 2;
   const deps = { players, COSTS: {}, POP_CAP: 10, placeGhost: () => false, isBlocked: () => false, neutral: { camps: [] }, dist2, packPower, campPower };
   const ai = new AIController(1, deps);
   ai.init();
-  ai.engage();
+  assert.strictEqual(ai.engage(), true);
   assert.ok(our1.retreat);
   assert.ok(our2.retreat);
+})();
+
+// engage returns false when no enemies are around
+(() => {
+  const unit = { type: 'soldier', hp: 40, dps: 4, vision: 100 };
+  const players = [
+    { units: [], structures: [], hero: null, ai: false },
+    {
+      units: [unit],
+      structures: [{ kind: 'square', x: 0, y: 0 }],
+      hero: null,
+      ai: true,
+      aiPlan: null,
+      res: { rice: 0, water: 0 },
+    },
+  ];
+  const deps = { players, COSTS: {}, POP_CAP: 10, placeGhost: () => false, isBlocked: () => false, neutral: { camps: [] }, dist2, packPower, campPower };
+  const ai = new AIController(1, deps);
+  ai.init();
+  assert.strictEqual(ai.engage(), false);
 })();
 
 // rallyAttack selects target among all enemies
@@ -144,7 +238,7 @@ const dist2 = (x1, y1, x2, y2) => (x1 - x2) ** 2 + (y1 - y2) ** 2;
   const ai = new AIController(1, deps);
   ai.init();
   ai.player.aiPlan.pushAt = 1;
-  ai.rallyAttack();
+  assert.strictEqual(ai.rallyAttack(), true);
   assert.strictEqual(unit.target, weak);
 })();
 


### PR DESCRIPTION
## Summary
- Return explicit success booleans from AI actions like `ensureHQ`, `buildOpenings`, `trainUnits`, and `engage`
- Bind action methods directly in `buildBehaviorTree` and stop sequences/selectors on `false`
- Add unit tests covering AI reactions to success/failure conditions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e4334606c8327b2a028544fc3276f