### PR TITLE
Refactor randomness, AI targeting, fog rendering, and state management

### DIFF
--- a/src/ai.js
+++ b/src/ai.js
@@ -453,13 +453,13 @@ class AIController {
         if (idx === this.id) return;
         if (pl.teamId !== undefined && P.teamId !== undefined && pl.teamId === P.teamId) return;
         const check = target => {
-          if (!target || target.isGhost) return;
+          if (!target || target.isGhost || target.dead) return;
           const def = target.hp || target.defense || 0;
           if (def < bestDef) { bestDef = def; best = target; }
         };
         check(pl.hero && !pl.hero.dead ? pl.hero : null);
-        pl.structures.forEach(check);
-        pl.units.forEach(u => { if (!u.isHero) check(u); });
+        pl.structures.forEach(s => { if (!s.dead && !s.isGhost) check(s); });
+        pl.units.forEach(u => { if (!u.isHero && !u.dead && !u.isGhost) check(u); });
       });
       if (best) {
         army.forEach(u => { if (!u.retreat) u.setTarget(best); });

--- a/src/entities.js
+++ b/src/entities.js
@@ -1,7 +1,13 @@
 /* ==== Entities ==== */
+import state from './state.js';
+
+export function defaultRand(min = 0, max = 1) {
+  return Math.random() * (max - min) + min;
+}
+
 let nextId = 1;
 
-function moveEntity(e, dx, dy, v, dt, isBlocked = globalThis.isBlocked) {
+function moveEntity(e, dx, dy, v, dt, isBlocked = state.isBlocked) {
   const d = Math.hypot(dx, dy);
   if (d <= 0) return;
   const nx = e.x + (dx / d) * v * dt, ny = e.y + (dy / d) * v * dt;
@@ -49,9 +55,9 @@ export class Unit extends Entity {
   constructor(x, y, owner, type = 'worker', deps = {}) {
     super(x, y, owner);
     this.deps = {
-      isBlocked: deps.isBlocked || globalThis.isBlocked || (() => false),
-      rand: deps.rand || globalThis.rand || Math.random,
-      players: deps.players || globalThis.players || [],
+      isBlocked: deps.isBlocked || state.isBlocked || (() => false),
+      rand: deps.rand || state.rand || defaultRand,
+      players: deps.players || state.players || [],
     };
     this.type = type;
     this.radius = 12;

--- a/src/fog.js
+++ b/src/fog.js
@@ -1,47 +1,88 @@
 /* ==== Fog of war ==== */
 const F_W = 180, F_H = 120;
 const explored = new Uint8Array(F_W * F_H), visible = new Uint8Array(F_W * F_H);
+const fogCanvas = document.createElement('canvas');
+fogCanvas.width = F_W;
+fogCanvas.height = F_H;
+const fogCtx = fogCanvas.getContext('2d');
+const fogImg = fogCtx.createImageData(F_W, F_H);
+const prevVisible = new Set();
+
 function fogIndex(wx, wy) {
   const { clamp, world } = globalThis;
   const x = clamp(Math.floor(wx / world.width * F_W), 0, F_W - 1);
   const y = clamp(Math.floor(wy / world.height * F_H), 0, F_H - 1);
   return y * F_W + x;
 }
-function clearVisible() { visible.fill(0); }
+
+function updatePixel(x, y) {
+  const idx = y * F_W + x;
+  let a = 0;
+  if (!explored[idx]) a = 220; else if (!visible[idx]) a = 120;
+  const j = idx * 4;
+  fogImg.data[j] = 0;
+  fogImg.data[j + 1] = 0;
+  fogImg.data[j + 2] = 0;
+  fogImg.data[j + 3] = a;
+}
+
+function commitRegion(x0, x1, y0, y1) {
+  fogCtx.putImageData(fogImg, 0, 0, x0, y0, x1 - x0 + 1, y1 - y0 + 1);
+}
+
+function clearVisible() {
+  if (!prevVisible.size) { visible.fill(0); return; }
+  let minX = F_W, minY = F_H, maxX = 0, maxY = 0;
+  for (const idx of prevVisible) {
+    visible[idx] = 0;
+    const x = idx % F_W, y = Math.floor(idx / F_W);
+    if (x < minX) minX = x;
+    if (y < minY) minY = y;
+    if (x > maxX) maxX = x;
+    if (y > maxY) maxY = y;
+    updatePixel(x, y);
+  }
+  commitRegion(minX, maxX, minY, maxY);
+  prevVisible.clear();
+}
+
 function revealCircle(wx, wy, r) {
   const { clamp, world } = globalThis;
-  const cx = Math.floor(wx / world.width * F_W), cy = Math.floor(wy / world.height * F_H), rr = (r / world.width * F_W), R2 = rr * rr;
-  const x0 = clamp(Math.floor(cx - rr - 1), 0, F_W - 1), x1 = clamp(Math.ceil(cx + rr + 1), 0, F_W - 1);
-  const y0 = clamp(Math.floor(cy - rr - 1), 0, F_H - 1), y1 = clamp(Math.ceil(cy + rr + 1), 0, F_H - 1);
+  const cx = Math.floor(wx / world.width * F_W);
+  const cy = Math.floor(wy / world.height * F_H);
+  const rr = (r / world.width * F_W);
+  const R2 = rr * rr;
+  const x0 = clamp(Math.floor(cx - rr - 1), 0, F_W - 1);
+  const x1 = clamp(Math.ceil(cx + rr + 1), 0, F_W - 1);
+  const y0 = clamp(Math.floor(cy - rr - 1), 0, F_H - 1);
+  const y1 = clamp(Math.ceil(cy + rr + 1), 0, F_H - 1);
   for (let y = y0; y <= y1; y++) {
     for (let x = x0; x <= x1; x++) {
       const dx = x - cx, dy = y - cy;
-      if (dx * dx + dy * dy <= R2) { visible[y * F_W + x] = 1; explored[y * F_W + x] = 1; }
-    }
-  }
-}
-function isVisible(wx, wy) { return !globalThis.fogEnabled || visible[fogIndex(wx, wy)] === 1; }
-function isExplored(wx, wy) { return !globalThis.fogEnabled || explored[fogIndex(wx, wy)] === 1; }
-function drawFog() {
-  const { fogEnabled, cvs, ctx, DPR, world } = globalThis;
-  if (!fogEnabled) return;
-  const w = cvs.width, h = cvs.height;
-  const img = ctx.createImageData(w, h);
-  for (let py = 0; py < h; py += 2) {
-    for (let px = 0; px < w; px += 2) {
-      const wx = (px / DPR) / world.zoom + world.camX,
-            wy = (py / DPR) / world.zoom + world.camY,
-            idx = fogIndex(wx, wy);
-      let a = 0;
-      if (!explored[idx]) a = 220; else if (!visible[idx]) a = 120;
-      for (let dy = 0; dy < 2; dy++) {
-        for (let dx = 0; dx < 2; dx++) {
-          const j = ((py + dy) * w + (px + dx)) * 4;
-          img.data[j] = 0; img.data[j + 1] = 0; img.data[j + 2] = 0; img.data[j + 3] = a;
-        }
+      if (dx * dx + dy * dy <= R2) {
+        const idx = y * F_W + x;
+        visible[idx] = 1;
+        explored[idx] = 1;
+        prevVisible.add(idx);
+        updatePixel(x, y);
       }
     }
   }
-  ctx.putImageData(img, 0, 0);
+  commitRegion(x0, x1, y0, y1);
 }
+
+function isVisible(wx, wy) {
+  return !globalThis.fogEnabled || visible[fogIndex(wx, wy)] === 1;
+}
+
+function isExplored(wx, wy) {
+  return !globalThis.fogEnabled || explored[fogIndex(wx, wy)] === 1;
+}
+
+function drawFog() {
+  const { fogEnabled, cvs, ctx } = globalThis;
+  if (!fogEnabled) return;
+  ctx.drawImage(fogCanvas, 0, 0, F_W, F_H, 0, 0, cvs.width, cvs.height);
+}
+
 Object.assign(globalThis, { F_W, F_H, explored, visible, fogIndex, clearVisible, revealCircle, isVisible, isExplored, drawFog });

--- a/src/main.js
+++ b/src/main.js
@@ -1,10 +1,12 @@
 import { drawSprite } from "./sprites.js";
 import { Unit, Structure, ResourceNode, ItemDrop, NeutralCreep, Projectile, getById, enemiesFor, allUnits, allStructures, nearestNode, lootFromTier } from "./entities.js";
+import state from './state.js';
 import { FireAuraEffect } from "./effects/FireAuraEffect.js";
 
 /* ==== Helpers ==== */
 const clamp = (v, a, b) => Math.max(a, Math.min(b, v));
 const rand = (a, b) => a + Math.random() * (b - a);
+state.rand = rand;
 const dist2 = (x1, y1, x2, y2) => { const dx = x2 - x1, dy = y2 - y1; return dx * dx + dy * dy; };
 
 /* ==== Canvas & camera ==== */
@@ -38,12 +40,12 @@ function drawShadow(x, y, r) { ctx.save(); ctx.fillStyle = 'rgba(0,0,0,0.25)'; c
 Object.assign(globalThis, { clamp, rand, dist2, cvs, ctx, mini, mctx, DPR, world, screenToWorld, worldToScreen, clampCam, toPixel, drawShadow });
 
 // provide a default isBlocked implementation until terrain initializes
-globalThis.isBlocked = globalThis.isBlocked || (() => false);
+state.isBlocked = state.isBlocked || (() => false);
 
 /* ==== Audio (простые огибающие без внешних файлов) ==== */
 const AC = window.AudioContext ? new AudioContext() : null;
 function beep(freq = 440, dur = 0.08, type = 'triangle', gain = 0.06) {
-  if (globalThis.muted || !AC) return;
+  if (state.muted || !AC) return;
   const o = AC.createOscillator(), g = AC.createGain();
   o.type = type; o.frequency.value = freq; o.connect(g); g.connect(AC.destination); g.gain.value = gain;
   o.start(); g.gain.exponentialRampToValueAtTime(0.0001, AC.currentTime + dur); o.stop(AC.currentTime + dur);
@@ -51,7 +53,7 @@ function beep(freq = 440, dur = 0.08, type = 'triangle', gain = 0.06) {
 globalThis.beep = beep;
 
 function playSfx(name) {
-  if (globalThis.muted || !AC) return;
+  if (state.muted || !AC) return;
   if (name === 'denied') {
     const o = AC.createOscillator(), g = AC.createGain();
     o.type = 'sine';
@@ -100,6 +102,7 @@ function drawWeather(dt) {
         { name: 'AI‑1', color: '#e05dff', res: { rice: 220, water: 100 }, units: [], structures: [], hero: null, ai: true, aiPlan: null, difficulty: 'easy', controller: null },
         { name: 'AI‑2', color: '#ffd27a', res: { rice: 220, water: 100 }, units: [], structures: [], hero: null, ai: true, aiPlan: null, difficulty: 'hard', controller: null }
       ];
+      state.players = players;
       const riceNodes = [], waterNodes = [];
       const resUI = { rice: document.getElementById('resRice'), water: document.getElementById('resWater'), pop: document.getElementById('pop'), idle: document.getElementById('idleWorkers') };
       const POP_CAP = 20;
@@ -115,7 +118,7 @@ function drawWeather(dt) {
       function canPlaceBuildingAt(x, y) {
         const R = 40;
         if (x < R || y < R || x > world.width - R || y > world.height - R) return false;
-        if (globalThis.isBlocked && globalThis.isBlocked(x, y)) return false;
+        if (state.isBlocked && state.isBlocked(x, y)) return false;
         for (const n of riceNodes) { if (dist2(x, y, n.x, n.y) <= (n.radius + R) * (n.radius + R)) return false; }
         for (const n of waterNodes) { if (dist2(x, y, n.x, n.y) <= (n.radius + R) * (n.radius + R)) return false; }
         for (const p of players) { for (const s of p.structures) { if (dist2(x, y, s.x, s.y) <= (s.radius + R) * (s.radius + R)) return false; } }
@@ -146,7 +149,7 @@ function drawWeather(dt) {
         if (unitType === 'archer') { u.dps = 20; u.maxHp = 120; u.hp = 120; u.attackRange = 250; u.vision = 520; u.regen = 0.25; }
         if (unitType === 'mage') { u.dps = 22; u.maxHp = 110; u.hp = 110; u.attackRange = 210; u.regen = 0.25; }
         players[owner].units.push(u);
-        if (!muted) beep(520, 0.06, 'sawtooth', 0.04);
+        if (!state.muted) beep(520, 0.06, 'sawtooth', 0.04);
         return true;
       }
 
@@ -156,7 +159,7 @@ function drawWeather(dt) {
           COSTS,
           POP_CAP,
           placeGhost,
-          isBlocked: (...args) => globalThis.isBlocked(...args),
+          isBlocked: (...args) => state.isBlocked(...args),
           neutral,
           dist2,
         };
@@ -164,7 +167,7 @@ function drawWeather(dt) {
 
       function getUnitDeps() {
         return {
-          isBlocked: (...args) => globalThis.isBlocked(...args),
+          isBlocked: (...args) => state.isBlocked(...args),
           rand,
           players,
         };
@@ -297,23 +300,23 @@ function drawWeather(dt) {
         const sign = remove ? -1 : 1;
         if (itemKind === 'scroll_hp') {
           if (remove) return;
-          hero.maxHp += 80; hero.hp = Math.min(hero.maxHp, hero.hp + 120); if (typeof beep === 'function' && !muted) beep(620, 0.08, 'triangle', 0.05);
+          hero.maxHp += 80; hero.hp = Math.min(hero.maxHp, hero.hp + 120); if (typeof beep === 'function' && !state.muted) beep(620, 0.08, 'triangle', 0.05);
         } else if (itemKind === 'scroll_dps') {
           if (remove) return;
-          hero.dps += 10; hero.auraTimer = 20; if (typeof beep === 'function' && !muted) beep(720, 0.08, 'square', 0.06);
+          hero.dps += 10; hero.auraTimer = 20; if (typeof beep === 'function' && !state.muted) beep(720, 0.08, 'square', 0.06);
           setTimeout(() => { hero.dps -= 10; }, 20000);
         } else if (itemKind === 'scroll_fire_aura') {
           if (remove) return;
           hero.effects.push(new FireAuraEffect({ radius: 100, dpsPerTick: 10, tickMs: 1000, durationMs: 20000 }));
-          if (typeof beep === 'function' && !muted) beep(640, 0.08, 'sawtooth', 0.06);
+          if (typeof beep === 'function' && !state.muted) beep(640, 0.08, 'sawtooth', 0.06);
         } else if (itemKind === 'ring_atk') {
-          hero.maxMp += 40 * sign; hero.mp += 40 * sign; if (!remove && typeof beep === 'function' && !muted) beep(540, 0.08, 'sawtooth', 0.05);
+          hero.maxMp += 40 * sign; hero.mp += 40 * sign; if (!remove && typeof beep === 'function' && !state.muted) beep(540, 0.08, 'sawtooth', 0.05);
         } else if (itemKind === 'boots') {
-          hero.baseSpeed += 20 * sign; hero.speed += 20 * sign; if (!remove && typeof beep === 'function' && !muted) beep(480, 0.08, 'square', 0.05);
+          hero.baseSpeed += 20 * sign; hero.speed += 20 * sign; if (!remove && typeof beep === 'function' && !state.muted) beep(480, 0.08, 'square', 0.05);
         } else if (itemKind === 'amulet') {
-          hero.maxHp += 120 * sign; hero.hp += 120 * sign; if (!remove && typeof beep === 'function' && !muted) beep(660, 0.08, 'triangle', 0.05);
+          hero.maxHp += 120 * sign; hero.hp += 120 * sign; if (!remove && typeof beep === 'function' && !state.muted) beep(660, 0.08, 'triangle', 0.05);
         } else if (itemKind === 'orb') {
-          hero.maxMp += 60 * sign; hero.mp += 60 * sign; if (!remove && typeof beep === 'function' && !muted) beep(580, 0.08, 'sawtooth', 0.05);
+          hero.maxMp += 60 * sign; hero.mp += 60 * sign; if (!remove && typeof beep === 'function' && !state.muted) beep(580, 0.08, 'sawtooth', 0.05);
         }
         if (hero.owner === 0) setHeroUI(hero);
       }
@@ -365,7 +368,7 @@ function drawWeather(dt) {
       window.addEventListener('keydown', e => {
         const k = e.key.toLowerCase();
         input.keys[k] = true;
-        if (k === 'f') globalThis.fogEnabled = !globalThis.fogEnabled;
+        if (k === 'f') state.fogEnabled = !state.fogEnabled;
         if (k === '1') tryCast(1);
         if (k === '2') tryCast(2);
         if (k === '3') tryCast(3);
@@ -609,7 +612,7 @@ globalThis.drawHp = drawHp;
       function loop(t) {
         const dt = Math.min(0.033, (t - last) / 1000); last = t; simTime += dt;
         clearVisible(); for (const s of players[0].structures) revealCircle(s.x, s.y, 520); for (const u of players[0].units) revealCircle(u.x, u.y, 480);
-        if (!globalThis.paused) {
+        if (!state.paused) {
           const sp = 900 / world.zoom; if (input.keys['w'] || input.keys['ц']) world.camY -= sp * dt; if (input.keys['s'] || input.keys['ы']) world.camY += sp * dt; if (input.keys['a'] || input.keys['ф']) world.camX -= sp * dt; if (input.keys['d'] || input.keys['в']) world.camX += sp * dt; clampCam();
           for (const p of players) {
             for (const s of p.structures) s.update(dt);

--- a/src/sprites.js
+++ b/src/sprites.js
@@ -215,6 +215,15 @@ export const SPRITES = {
 };
 
 const CACHE = new Map();
+const CACHE_LIMIT = 200;
+
+function stableKey(obj) {
+  const sorted = Object.keys(obj).sort().reduce((acc, k) => {
+    acc[k] = obj[k];
+    return acc;
+  }, {});
+  return JSON.stringify(sorted);
+}
 
 export function drawSprite(ctx, name, x, y, opts = {}) {
   const spr = SPRITES[name];
@@ -233,7 +242,7 @@ export function drawSprite(ctx, name, x, y, opts = {}) {
   const h = spr.length;
   let canvas = null;
   if (!flipX && !flipY && !rotate && alpha === 1 && !shadow) {
-    const key = name + '@' + scale + '@' + JSON.stringify(override);
+    const key = name + '@' + scale + '@' + stableKey(override);
     canvas = CACHE.get(key);
     if (!canvas) {
       canvas = document.createElement('canvas');
@@ -252,6 +261,10 @@ export function drawSprite(ctx, name, x, y, opts = {}) {
         }
       }
       CACHE.set(key, canvas);
+      if (CACHE.size > CACHE_LIMIT) {
+        const firstKey = CACHE.keys().next().value;
+        CACHE.delete(firstKey);
+      }
     }
   }
   const tp = globalThis.toPixel || (v => v);

--- a/src/state.js
+++ b/src/state.js
@@ -1,0 +1,17 @@
+export const state = {
+  paused: true,
+  muted: false,
+  fogEnabled: true,
+  players: [],
+  isBlocked: (...args) => false,
+  rand: (min = 0, max = 1) => Math.random() * (max - min) + min,
+};
+
+export default state;
+
+['paused', 'muted', 'fogEnabled', 'players', 'isBlocked', 'rand'].forEach(key => {
+  Object.defineProperty(globalThis, key, {
+    get: () => state[key],
+    set: v => { state[key] = v; },
+  });
+});

--- a/src/ui.js
+++ b/src/ui.js
@@ -1,4 +1,6 @@
 /* ==== Menu & toggles ==== */
+import state from './state.js';
+
 const menu = document.getElementById('menu');
 const btnStart = document.getElementById('btnStart');
 const btnRestart = document.getElementById('btnRestart');
@@ -11,38 +13,38 @@ const btnResultRestart = document.getElementById('btnResultRestart');
 const idleWorkersEl = document.getElementById('idleWorkers');
 globalThis.idleWorkersEl = idleWorkersEl;
 
-globalThis.paused = true;
-globalThis.muted = false;
-globalThis.fogEnabled = true;
+state.paused = true;
+state.muted = false;
+state.fogEnabled = true;
 
 btnStart.onclick = async () => {
   resultMenu.style.display = 'none';
   menu.style.display = 'none';
   await globalThis.resetGame();
-  globalThis.paused = false;
+  state.paused = false;
 };
 btnRestart.onclick = async () => {
   resultMenu.style.display = 'none';
   menu.style.display = 'none';
   await globalThis.resetGame();
-  globalThis.paused = false;
+  state.paused = false;
 };
-btnMute.onclick = () => { globalThis.muted = !globalThis.muted; btnMute.textContent = globalThis.muted ? 'Звук: выкл' : 'Звук: вкл'; };
+btnMute.onclick = () => { state.muted = !state.muted; btnMute.textContent = state.muted ? 'Звук: выкл' : 'Звук: вкл'; };
 btnPause.onclick = () => {
-  globalThis.paused = !globalThis.paused;
-  if (globalThis.paused) document.getElementById('heroSelect').style.display = 'none';
-  menu.style.display = globalThis.paused ? 'flex' : 'none';
+  state.paused = !state.paused;
+  if (state.paused) document.getElementById('heroSelect').style.display = 'none';
+  menu.style.display = state.paused ? 'flex' : 'none';
 };
-btnFog.onclick = () => { globalThis.fogEnabled = !globalThis.fogEnabled; btnFog.textContent = globalThis.fogEnabled ? 'No Fog' : 'Fog'; };
+btnFog.onclick = () => { state.fogEnabled = !state.fogEnabled; btnFog.textContent = state.fogEnabled ? 'No Fog' : 'Fog'; };
 
 btnResultRestart.onclick = () => {
   resultMenu.style.display = 'none';
   menu.style.display = 'flex';
-  globalThis.paused = true;
+  state.paused = true;
 };
 
 globalThis.showResultMenu = (msg) => {
-  globalThis.paused = true;
+  state.paused = true;
   if (globalThis.setHeroUI) globalThis.setHeroUI(null);
   resultText.textContent = msg;
   menu.style.display = 'none';


### PR DESCRIPTION
## Summary
- Add `defaultRand` utility and plumb centralized state, removing implicit global dependencies
- Skip dead or ghost units in `rallyAttack`
- Cache fog of war on an offscreen canvas for incremental updates
- Stabilize sprite cache keys and limit cache growth

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ecb10627c83279f49a292b2580861