### PR TITLE
Stabilize neutral state and AI initialization

### DIFF
--- a/src/entities.js
+++ b/src/entities.js
@@ -674,30 +674,30 @@ export class NeutralCreep extends Entity {
 
 export function getById(id) {
   if (!id) return null;
-  for (const p of globalThis.players) {
+  for (const p of state.players) {
     for (const u of p.units) { if (u.id === id) return u; }
     for (const s of p.structures) { if (s.id === id) return s; }
   }
-  for (const n of globalThis.neutral.units) { if (n.id === id) return n; }
+  for (const n of state.neutral.units) { if (n.id === id) return n; }
   return null;
 }
 
 export function enemiesFor(owner) {
   const arr = [];
-  for (const p of globalThis.players) {
-    if (p === globalThis.players[owner]) continue;
+  for (const p of state.players) {
+    if (p === state.players[owner]) continue;
     arr.push(...p.units.filter(u => !u.dead), ...p.structures.filter(s => !s.isGhost));
   }
-  arr.push(...globalThis.neutral.units);
+  arr.push(...state.neutral.units);
   return arr;
 }
 
 export function allUnits() {
-  return globalThis.players[0].units.concat(globalThis.players[1].units, globalThis.players[2].units);
+  return state.players[0].units.concat(state.players[1].units, state.players[2].units);
 }
 
 export function allStructures() {
-  return globalThis.players[0].structures.concat(globalThis.players[1].structures, globalThis.players[2].structures);
+  return state.players[0].structures.concat(state.players[1].structures, state.players[2].structures);
 }
 
 export function nearestNode(type, P) {

--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,7 @@
 import { drawSprite } from "./sprites.js";
 import { Unit, Structure, ResourceNode, ItemDrop, NeutralCreep, Projectile, getById, enemiesFor, allUnits, allStructures, nearestNode, lootFromTier } from "./entities.js";
 import state from './state.js';
+import { AIController } from './ai.js';
 import { FireAuraEffect } from "./effects/FireAuraEffect.js";
 
 /* ==== Helpers ==== */
@@ -95,6 +96,7 @@ function drawWeather(dt) {
   }
 }
       const neutral = { units: [] }, drops = [], projectiles = [];
+      state.neutral = neutral;
 
       /* ==== Players & economy ==== */
       const players = [

--- a/src/state.js
+++ b/src/state.js
@@ -3,13 +3,14 @@ export const state = {
   muted: false,
   fogEnabled: true,
   players: [],
+  neutral: { units: [] },
   isBlocked: (...args) => false,
   rand: (min = 0, max = 1) => Math.random() * (max - min) + min,
 };
 
 export default state;
 
-['paused', 'muted', 'fogEnabled', 'players', 'isBlocked', 'rand'].forEach(key => {
+['paused', 'muted', 'fogEnabled', 'players', 'neutral', 'isBlocked', 'rand'].forEach(key => {
   Object.defineProperty(globalThis, key, {
     get: () => state[key],
     set: v => { state[key] = v; },


### PR DESCRIPTION
## Summary
- Share neutral units through global state to avoid disappearance on reset
- Statically import AI controller in main module to ensure bot availability
- Update entity lookups to rely on central state

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ed8d698408327adc696a3418a3c91