### PR TITLE
Improve UI accessibility and graphics

### DIFF
--- a/docs/MiniRTS_Ultra_FULL_NoSprites_v12_1755074840.html
+++ b/docs/MiniRTS_Ultra_FULL_NoSprites_v12_1755074840.html
@@ -17,8 +17,8 @@
     <span class="pill">💧 Вода: <span id="resWater">0</span></span>
     <span class="pill">👥 Поп: <span id="pop">0</span>/20</span>
     <span class="pill">😴 Idle: <span id="idleWorkers">0</span></span>
-    <button id="btnFog">No Fog</button>
-    <button id="btnPause">Меню</button>
+    <button id="btnFog" class="btn-base">No Fog</button>
+    <button id="btnPause" class="btn-base">Меню</button>
   </div>
 
   <div class="panel" id="unitPanel"></div>
@@ -34,9 +34,9 @@
     </div>
     <div id="expBar"><div id="expFill"></div></div>
     <div class="hero-abilities">
-      <button class="btn" id="ab1">1</button>
-      <button class="btn" id="ab2">2</button>
-      <button class="btn" id="ab3">3</button>
+      <button class="btn-base btn" id="ab1">1</button>
+      <button class="btn-base btn" id="ab2">2</button>
+      <button class="btn-base btn" id="ab3">3</button>
     </div>
     <div id="abilityDesc"></div>
   </div>
@@ -53,9 +53,9 @@
     <div class="card">
       <h3>Выберите героя</h3>
       <div class="heroChoice">
-        <button class="btn heroBtn" data-cls="paladin">Паладин</button>
-        <button class="btn heroBtn" data-cls="rogue">Разбойник</button>
-        <button class="btn heroBtn" data-cls="archmage">Аркан‑маг</button>
+        <button class="btn-base btn heroBtn" data-cls="paladin">Паладин</button>
+        <button class="btn-base btn heroBtn" data-cls="rogue">Разбойник</button>
+        <button class="btn-base btn heroBtn" data-cls="archmage">Аркан‑маг</button>
       </div>
     </div>
   </div>
@@ -66,9 +66,9 @@
       <p>Полный функционал: ИИ, добыча рис/воды, строительство, туман/миником, герои с умениями, лут с нейтралов,
         инвентарь, приоритет отступления и атаки на героя.</p>
       <div class="menu-actions">
-        <button id="btnStart" class="btn">Начать</button>
-        <button id="btnRestart" class="btn">Новая игра</button>
-        <button id="btnMute" class="btn">Звук: вкл</button>
+        <button id="btnStart" class="btn-base btn">Начать</button>
+        <button id="btnRestart" class="btn-base btn">Новая игра</button>
+        <button id="btnMute" class="btn-base btn">Звук: вкл</button>
       </div>
       <div class="menu-tip">ЛКМ — выбор / ПКМ — приказ. Дабл‑клик — выбрать всех юнитов
         типа на экране. WASD — камера. 1/2/3 — умения героя. U — использовать предмет. R — рабочие к работе. B/M/T/L/H —
@@ -80,7 +80,7 @@
     <div class="card">
       <h2 id="resultText">Победа!</h2>
       <div class="center-row">
-        <button id="btnResultRestart" class="btn">В меню</button>
+        <button id="btnResultRestart" class="btn-base btn">В меню</button>
       </div>
     </div>
   </div>

--- a/src/main.js
+++ b/src/main.js
@@ -15,6 +15,9 @@ const cvs = document.getElementById('game'), ctx = cvs.getContext('2d'); ctx.ima
 const mini = document.getElementById('minimap'), mctx = mini.getContext('2d'); mctx.imageSmoothingEnabled = false;
 globalThis.drawSprite = (name, x, y, scale = 1, override = {}) => drawSprite(ctx, name, x, y, { scale, override });
 const DPR = Math.max(1, window.devicePixelRatio || 1);
+mini.width = Math.floor(mini.clientWidth * DPR);
+mini.height = Math.floor(mini.clientHeight * DPR);
+mctx.setTransform(DPR, 0, 0, DPR, 0, 0);
 const world = { width: 12000, height: 8000, camX: 0, camY: 0, zoom: 1.25 };
 function resize() { const w = cvs.clientWidth, h = cvs.clientHeight; cvs.width = Math.floor(w * DPR); cvs.height = Math.floor(h * DPR); ctx.setTransform(DPR, 0, 0, DPR, 0, 0); }
 new ResizeObserver(resize).observe(cvs); resize();
@@ -278,7 +281,7 @@ function drawWeather(dt) {
         invPanel.style.display = 'block'; invGrid.innerHTML = '';
         const cap = 6, arr = (hero.inventory || []).slice(0, cap);
         for (let i = 0; i < cap; i++) {
-          const slot = document.createElement('div'); slot.className = 'invSlot';
+          const slot = document.createElement('div'); slot.className = 'invSlot btn-base';
           if (arr[i]) {
             const it = arr[i]; const inf = itemInfo[it]; const hk = invHotkeys[i];
             const canvas = document.createElement('canvas'); canvas.width = 32; canvas.height = 32; const cctx = canvas.getContext('2d'); cctx.imageSmoothingEnabled = false;

--- a/style.css
+++ b/style.css
@@ -1,35 +1,41 @@
-    :root {
-      --panel-bg: rgba(0, 0, 0, .55);
-      --panel-border: rgba(255, 255, 255, .12);
-      --btn-bg: rgba(255, 255, 255, .08);
-      --btn-border: rgba(255, 255, 255, .18);
-    }
 
-    html,
-    body {
-      margin: 0;
-      padding: 0;
-      height: 100%;
-      background: #0b0f13;
-      color: #eef;
-      font-family: system-ui, Segoe UI, Arial, sans-serif;
-      user-select: none
-    }
+:root {
+  --text-color: #fff;
+  --panel-bg: rgba(0, 0, 0, .65);
+  --panel-border: rgba(255, 255, 255, .12);
+  --btn-bg: rgba(255, 255, 255, .08);
+  --btn-border: rgba(255, 255, 255, .18);
+}
 
-    #game {
-      display: block;
-      width: 100vw;
-      height: 100dvh;
-      outline: none;
-      image-rendering: pixelated
-    }
+html,
+body {
+  margin: 0;
+  padding: 0;
+  height: 100%;
+  background: #0b0f13;
+  color: var(--text-color);
+  font-family: system-ui, Segoe UI, Arial, sans-serif;
+  user-select: none
+}
+
+#game {
+  display: block;
+  width: 100vw;
+  height: 100vh;
+  outline: none;
+  image-rendering: pixelated
+}
+
+@supports (height: 100dvh) {
+  #game { height: 100dvh; }
+}
 
     #ui {
       position: fixed;
       left: 12px;
       top: 12px;
       z-index: 80;
-      background: rgba(0, 0, 0, .5);
+      background: var(--panel-bg);
       border: 1px solid var(--panel-border);
       padding: 8px 10px;
       border-radius: 10px
@@ -45,19 +51,24 @@
       font-weight: 700
     }
 
-    #ui button {
-      margin-left: 6px;
-      padding: 6px 10px;
-      border-radius: 8px;
-      border: 1px solid var(--btn-border);
-      background: var(--btn-bg);
-      color: #fff;
-      cursor: pointer;
-      transition: background .15s, transform .1s
-    }
+#ui button { margin-left: 6px; }
 
-    #ui button:hover { background: rgba(255,255,255,.15); }
-    #ui button:active { transform: scale(0.96); }
+.btn-base {
+  padding: 6px 10px;
+  border-radius: 8px;
+  border: 1px solid var(--btn-border);
+  background: var(--btn-bg);
+  color: var(--text-color);
+  cursor: pointer;
+  transition: background .15s, transform .1s;
+}
+
+.btn-base:hover { background: rgba(255,255,255,.15); }
+.btn-base:active { transform: scale(0.96); }
+.btn-base:focus-visible {
+  outline: 2px solid var(--text-color);
+  outline-offset: 2px;
+}
 
     .panel {
       position: fixed;
@@ -139,18 +150,7 @@
       white-space: pre-line
     }
 
-    .btn {
-      margin: 2px 4px;
-      padding: 6px 10px;
-      border-radius: 8px;
-      border: 1px solid var(--btn-border);
-      background: var(--btn-bg);
-      color: #fff;
-      cursor: pointer;
-      transition: background .15s, transform .1s
-    }
-    .btn:hover { background: rgba(255,255,255,.15); }
-    .btn:active { transform: scale(0.96); }
+.btn { margin: 2px 4px; }
 
     .invGrid {
       display: grid;
@@ -158,22 +158,18 @@
       grid-gap: 6px
     }
 
-    .invSlot {
-      width: 52px;
-      height: 52px;
-      border: 1px solid rgba(255, 255, 255, .15);
-      border-radius: 8px;
-      background: rgba(255, 255, 255, .06);
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      font-size: 11px;
-      text-align: center;
-      cursor: pointer;
-      transition: background .15s, transform .1s
-    }
-    .invSlot:hover { background: rgba(255,255,255,.12); }
-    .invSlot:active { transform: scale(0.96); }
+.invSlot {
+  width: 52px;
+  height: 52px;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 11px;
+  text-align: center;
+  background: var(--btn-bg);
+}
+.invSlot:hover { background: rgba(255,255,255,.12); }
     .invSlot.flash {
       animation: invFlash 0.15s;
     }


### PR DESCRIPTION
## Summary
- Improve contrast by defining text and panel color variables
- Add 100vh fallback and dvh @supports for game canvas
- Introduce `.btn-base` utility with focus styles and apply to buttons and inventory slots
- Scale minimap for HiDPI displays

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689eebb85144832798867a7ff3117041