### PR TITLE
feat: integrate worker sprite atlas

### DIFF
--- a/src/entities.js
+++ b/src/entities.js
@@ -261,56 +261,66 @@ export class Unit extends Entity {
     const ctx = globalThis.ctx;
     const col = globalThis.players[this.owner]?.color || '#9fb2a1';
     globalThis.drawShadow(s.x, s.y + 12 * zoom, 12 * zoom);
-    ctx.save();
-    ctx.translate(s.x, s.y);
-    ctx.scale(zoom, zoom);
-    const grad = ctx.createLinearGradient(0, -12, 0, 12);
-    grad.addColorStop(0, '#f0f0f0');
-    grad.addColorStop(1, '#bdbdbd');
-    ctx.fillStyle = grad;
-    ctx.beginPath();
-    ctx.arc(0, -8, 8, Math.PI, 0);
-    ctx.lineTo(8, 8);
-    ctx.arc(0, 8, 8, 0, Math.PI);
-    ctx.closePath();
-    ctx.fill();
-    ctx.fillStyle = col;
-    ctx.fillRect(-8, -2, 16, 4);
-    // unique icons for unit types
-    if (this.type === 'worker') {
-      // small hammer on the side
-      ctx.strokeStyle = '#ccc';
-      ctx.lineWidth = 2;
+    if (this.type === 'worker' && !this.isHero && globalThis.nextFrame) {
+      const movingStates = ['move', 'to_node', 'to_hq', 'build'];
+      let animName = 'worker_idle';
+      if (this.state === 'harvest') animName = 'worker_gather';
+      else if (movingStates.includes(this.state)) animName = 'worker_walk';
+      else if (this.state === 'fight') animName = 'worker_attack';
+      const frame = globalThis.nextFrame(animName, globalThis.simTime || 0) || 'worker_idle_0';
+      globalThis.drawSprite(frame, s.x, s.y, zoom);
+    } else {
+      ctx.save();
+      ctx.translate(s.x, s.y);
+      ctx.scale(zoom, zoom);
+      const grad = ctx.createLinearGradient(0, -12, 0, 12);
+      grad.addColorStop(0, '#f0f0f0');
+      grad.addColorStop(1, '#bdbdbd');
+      ctx.fillStyle = grad;
       ctx.beginPath();
-      ctx.moveTo(10, -6);
-      ctx.lineTo(14, -10);
-      ctx.moveTo(10, -6);
-      ctx.lineTo(14, -2);
-      ctx.stroke();
-    } else if (this.type === 'soldier') {
-      // blade for swordsman
-      ctx.fillStyle = '#ccc';
-      ctx.beginPath();
-      ctx.moveTo(-12, -4);
-      ctx.lineTo(-8, 0);
-      ctx.lineTo(-12, 4);
+      ctx.arc(0, -8, 8, Math.PI, 0);
+      ctx.lineTo(8, 8);
+      ctx.arc(0, 8, 8, 0, Math.PI);
       ctx.closePath();
       ctx.fill();
-    } else if (this.type === 'archer') {
-      // bow arc
-      ctx.strokeStyle = '#da8';
-      ctx.lineWidth = 2;
-      ctx.beginPath();
-      ctx.arc(12, 0, 6, -Math.PI / 2, Math.PI / 2);
-      ctx.stroke();
-    } else if (this.type === 'mage') {
-      // magic orb/staff
-      ctx.fillStyle = '#8ad';
-      ctx.beginPath();
-      ctx.arc(0, -14, 4, 0, 6.283);
-      ctx.fill();
+      ctx.fillStyle = col;
+      ctx.fillRect(-8, -2, 16, 4);
+      // unique icons for unit types
+      if (this.type === 'worker') {
+        // small hammer on the side
+        ctx.strokeStyle = '#ccc';
+        ctx.lineWidth = 2;
+        ctx.beginPath();
+        ctx.moveTo(10, -6);
+        ctx.lineTo(14, -10);
+        ctx.moveTo(10, -6);
+        ctx.lineTo(14, -2);
+        ctx.stroke();
+      } else if (this.type === 'soldier') {
+        // blade for swordsman
+        ctx.fillStyle = '#ccc';
+        ctx.beginPath();
+        ctx.moveTo(-12, -4);
+        ctx.lineTo(-8, 0);
+        ctx.lineTo(-12, 4);
+        ctx.closePath();
+        ctx.fill();
+      } else if (this.type === 'archer') {
+        // bow arc
+        ctx.strokeStyle = '#da8';
+        ctx.lineWidth = 2;
+        ctx.beginPath();
+        ctx.arc(12, 0, 6, -Math.PI / 2, Math.PI / 2);
+        ctx.stroke();
+      } else if (this.type === 'mage') {
+        // magic orb/staff
+        ctx.fillStyle = '#8ad';
+        ctx.beginPath();
+        ctx.arc(0, -14, 4, 0, 6.283);
+        ctx.fill();
+      }
+      ctx.restore();
     }
-    ctx.restore();
     globalThis.drawHp(s.x, s.y - 18 * zoom, this.hp / this.maxHp);
     for (const eff of this.effects) {
       if (eff.draw) eff.draw(ctx, this);

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,4 @@
-import { drawSprite } from "./sprites.js";
+import { drawSprite, initSprites } from "./sprites.js";
 import { Unit, Structure, ResourceNode, ItemDrop, NeutralCreep, Projectile, getById, enemiesFor, allUnits, allStructures, nearestNode, lootFromTier } from "./entities.js";
 import state from './state.js';
 import { AIController } from './ai.js';
@@ -14,6 +14,7 @@ const dist2 = (x1, y1, x2, y2) => { const dx = x2 - x1, dy = y2 - y1; return dx 
 const cvs = document.getElementById('game'), ctx = cvs.getContext('2d'); ctx.imageSmoothingEnabled = false;
 const mini = document.getElementById('minimap'), mctx = mini.getContext('2d'); mctx.imageSmoothingEnabled = false;
 globalThis.drawSprite = (name, x, y, scale = 1, override = {}) => drawSprite(ctx, name, x, y, { scale, override });
+initSprites();
 const DPR = Math.max(1, window.devicePixelRatio || 1);
 mini.width = Math.floor(mini.clientWidth * DPR);
 mini.height = Math.floor(mini.clientHeight * DPR);
@@ -615,7 +616,7 @@ globalThis.resetGame = resetGame;
       function drawHp(x, y, k) { k = clamp(k, 0, 1); ctx.fillStyle = 'rgba(0,0,0,.55)'; ctx.fillRect(x - 18, y - 4, 36, 6); ctx.fillStyle = k > .5 ? '#6be36b' : (k > .25 ? '#ffd36b' : '#ff6b6b'); ctx.fillRect(x - 18, y - 4, 36 * k, 6); ctx.strokeStyle = 'rgba(255,255,255,.15)'; ctx.strokeRect(x - 18, y - 4, 36, 6); }
 globalThis.drawHp = drawHp;
       function loop(t) {
-        const dt = Math.min(0.033, (t - last) / 1000); last = t; simTime += dt;
+        const dt = Math.min(0.033, (t - last) / 1000); last = t; simTime += dt; globalThis.simTime = simTime;
         clearVisible(); for (const s of players[0].structures) revealCircle(s.x, s.y, 520); for (const u of players[0].units) revealCircle(u.x, u.y, 480);
         if (!state.paused) {
           const sp = 900 / world.zoom; if (input.keys['w'] || input.keys['ц']) world.camY -= sp * dt; if (input.keys['s'] || input.keys['ы']) world.camY += sp * dt; if (input.keys['a'] || input.keys['ф']) world.camX -= sp * dt; if (input.keys['d'] || input.keys['в']) world.camX += sp * dt; clampCam();

--- a/src/sprites.js
+++ b/src/sprites.js
@@ -354,6 +354,43 @@ export const SPRITES = {
   ]
 };
 
+// Sprite atlas support
+let FRAMES = {}, ANIMS = {};
+
+async function loadAtlas(jsonUrl) {
+  try {
+    const meta = await fetch(jsonUrl).then(r => r.json());
+    const img = new Image(); img.decoding = 'async';
+    img.src = meta.imageData || meta.image || jsonUrl.replace('.json', '.png');
+    await img.decode();
+    return { img, meta };
+  } catch (e) {
+    return null;
+  }
+}
+
+export async function initSprites() {
+  const base = await loadAtlas('docs/sprites.json');
+  if (base) {
+    FRAMES = { ...FRAMES, ...base.meta.frames };
+    ANIMS = { ...ANIMS, ...(base.meta.animations || {}) };
+    globalThis.__SPRITE_IMG__ = base.img;
+  }
+  const worker = await loadAtlas('docs/worker_sprites.json');
+  if (worker) {
+    FRAMES = { ...FRAMES, ...worker.meta.frames };
+    ANIMS = { ...ANIMS, ...worker.meta.animations };
+    globalThis.__SPRITE_IMG_WORKER__ = worker.img;
+  }
+}
+
+export function nextFrame(anim, t) {
+  const seq = ANIMS[anim];
+  if (!seq) return null;
+  const idx = Math.floor((t * 10) % seq.length);
+  return seq[idx];
+}
+
 const CACHE = new Map();
 const CACHE_LIMIT = 200;
 
@@ -410,6 +447,34 @@ function buildSpriteImage(key, spr, w, h, scale, override) {
 }
 
 export function drawSprite(ctx, name, x, y, opts = {}) {
+  if (FRAMES[name]) {
+    const f = FRAMES[name];
+    const {
+      scale = 1,
+      alpha = 1,
+      flipX = false,
+      flipY = false,
+      rotate = 0,
+    } = opts;
+    const img = name.startsWith('worker_') ? globalThis.__SPRITE_IMG_WORKER__ : globalThis.__SPRITE_IMG__;
+    if (!img) return;
+    ctx.save();
+    ctx.imageSmoothingEnabled = false;
+    ctx.globalAlpha *= alpha;
+    ctx.translate(x, y);
+    if (rotate) ctx.rotate(rotate);
+    ctx.scale(flipX ? -1 : 1, flipY ? -1 : 1);
+    const ax = f.anchor?.x ?? 0;
+    const ay = f.anchor?.y ?? 0;
+    ctx.drawImage(
+      img,
+      f.frame.x, f.frame.y, f.frame.w, f.frame.h,
+      Math.floor(-ax * scale), Math.floor(-ay * scale),
+      f.frame.w * scale, f.frame.h * scale
+    );
+    ctx.restore();
+    return;
+  }
   let spr = SPRITES[name];
   if (!spr) return;
   const {


### PR DESCRIPTION
## Summary
- load worker sprite atlas and animations
- render worker units with animated sprite frames
- expose simulation time for frame updates

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ef9a191b88327805addb6b32ccaa9