### PR TITLE
Fix worker sprite asset path

### DIFF
--- a/docs/worker_sprites.json
+++ b/docs/worker_sprites.json
@@ -1,5 +1,5 @@
 {
-  "image": "docs/worker_sprites.png",
+  "image": "worker_sprites.png",
   "tile": {
     "w": 32,
     "h": 32

--- a/src/sprites.js
+++ b/src/sprites.js
@@ -361,7 +361,9 @@ async function loadAtlas(jsonUrl) {
   try {
     const meta = await fetch(jsonUrl).then(r => r.json());
     const img = new Image(); img.decoding = 'async';
-    img.src = meta.imageData || meta.image || jsonUrl.replace('.json', '.png');
+    const base = new URL(jsonUrl, typeof location !== 'undefined' ? location.href : 'https://example.com/');
+    const src = meta.imageData || meta.image || jsonUrl.replace('.json', '.png');
+    img.src = meta.imageData ? src : new URL(src, base).toString();
     await img.decode();
     return { img, meta };
   } catch (e) {
@@ -370,13 +372,14 @@ async function loadAtlas(jsonUrl) {
 }
 
 export async function initSprites() {
-  const base = await loadAtlas('docs/sprites.json');
+  const prefix = (typeof location !== 'undefined' && location.pathname.includes('/docs/')) ? '' : 'docs/';
+  const base = await loadAtlas(prefix + 'sprites.json');
   if (base) {
     FRAMES = { ...FRAMES, ...base.meta.frames };
     ANIMS = { ...ANIMS, ...(base.meta.animations || {}) };
     globalThis.__SPRITE_IMG__ = base.img;
   }
-  const worker = await loadAtlas('docs/worker_sprites.json');
+  const worker = await loadAtlas(prefix + 'worker_sprites.json');
   if (worker) {
     FRAMES = { ...FRAMES, ...worker.meta.frames };
     ANIMS = { ...ANIMS, ...worker.meta.animations };


### PR DESCRIPTION
## Summary
- resolve sprite atlas images relative to JSON files and support docs root
- load worker sprite atlas correctly regardless of deployment path
- point worker sprite atlas to the correct image file

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689efd641ad88327a833e491bd794d6e