### PR TITLE
Add mage and terrain sprite atlases

### DIFF
--- a/src/entities.js
+++ b/src/entities.js
@@ -261,6 +261,16 @@ export class Unit extends Entity {
     const ctx = globalThis.ctx;
     const col = globalThis.players[this.owner]?.color || '#9fb2a1';
     globalThis.drawShadow(s.x, s.y + 12 * zoom, 12 * zoom);
+    if (this.isHero && globalThis.nextFrame && globalThis.drawSprite) {
+      let anim = 'mage_idle';
+      if (this.dead) anim = 'mage_death';
+      else if (this.state === 'cast') anim = 'mage_cast';
+      else if (this.state === 'fight') anim = 'mage_attack';
+      else if (this.state === 'move') anim = 'mage_walk';
+      const frame = globalThis.nextFrame(anim, globalThis.simTime || 0, anim === 'mage_cast' ? 12 : 10) || 'mage_idle_0';
+      globalThis.drawSprite(frame, s.x, s.y, zoom);
+      return;
+    }
     if (this.type === 'worker' && !this.isHero && globalThis.nextFrame) {
       const movingStates = ['move', 'to_node', 'to_hq', 'build'];
       let animName = 'worker_idle';

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,4 @@
-import { drawSprite, initSprites, nextFrame } from "./sprites.js";
+import { drawSprite, nextFrame, initSprites, initWorkerAtlas, initMageAtlas, initTerrainAtlas } from "./sprites.js";
 import { Unit, Structure, ResourceNode, ItemDrop, NeutralCreep, Projectile, getById, enemiesFor, allUnits, allStructures, nearestNode, lootFromTier } from "./entities.js";
 import state from './state.js';
 import { AIController } from './ai.js';
@@ -15,7 +15,10 @@ const cvs = document.getElementById('game'), ctx = cvs.getContext('2d'); ctx.ima
 const mini = document.getElementById('minimap'), mctx = mini.getContext('2d'); mctx.imageSmoothingEnabled = false;
 globalThis.drawSprite = (name, x, y, scale = 1, override = {}) => drawSprite(ctx, name, x, y, { scale, override });
 globalThis.nextFrame = nextFrame;
-initSprites();
+await initSprites();
+await initWorkerAtlas();
+await initMageAtlas();
+await initTerrainAtlas();
 const DPR = Math.max(1, window.devicePixelRatio || 1);
 mini.width = Math.floor(mini.clientWidth * DPR);
 mini.height = Math.floor(mini.clientHeight * DPR);

--- a/src/sprites.js
+++ b/src/sprites.js
@@ -356,38 +356,57 @@ export const SPRITES = {
 
 // Sprite atlas support
 let FRAMES = {}, ANIMS = {};
+globalThis.FRAMES = FRAMES;
+globalThis.ANIMS = ANIMS;
 
-async function loadAtlas(jsonUrl) {
-  try {
-    const meta = await fetch(jsonUrl).then(r => r.json());
-    const img = new Image(); img.decoding = 'async';
-    const base = new URL(jsonUrl, typeof location !== 'undefined' ? location.href : 'https://example.com/');
-    const src = meta.imageData || meta.image || jsonUrl.replace('.json', '.png');
-    img.src = meta.imageData ? src : new URL(src, base).toString();
-    await img.decode();
-    return { img, meta };
-  } catch (e) {
-    return null;
-  }
+const __DOCS = new URL('../docs/', import.meta.url);
+async function __loadAtlas(name) {
+  const u1 = new URL(name, __DOCS).href;
+  let res = await fetch(u1).catch(() => null);
+  if (!res || !res.ok) res = await fetch(name).catch(() => null);
+  if (!res || !res.ok) throw new Error('Failed to load ' + name);
+  const meta = await res.json();
+  const img = new Image(); img.decoding = 'async';
+  img.src = meta.imageData || new URL(meta.image || name.replace('.json', '.png'), __DOCS).href;
+  try { await img.decode(); } catch {}
+  return { img, meta };
 }
 
 export async function initSprites() {
-  const prefix = (typeof location !== 'undefined' && location.pathname.includes('/docs/')) ? '' : 'docs/';
-  const worker = await loadAtlas(prefix + 'worker_sprites.json');
-  if (worker) {
-    FRAMES = { ...FRAMES, ...worker.meta.frames };
-    ANIMS = { ...ANIMS, ...worker.meta.animations };
-    globalThis.__SPRITE_IMG_WORKER__ = worker.img;
-    if (!globalThis.__SPRITE_IMG__) {
-      globalThis.__SPRITE_IMG__ = worker.img;
-    }
+  // baseline sprites already available; nothing to do here for now
+}
+
+export async function initWorkerAtlas() {
+  const a = await __loadAtlas('worker_sprites.json').catch(() => null);
+  if (!a) return;
+  Object.assign(FRAMES, a.meta.frames || {});
+  Object.assign(ANIMS, a.meta.animations || {});
+  globalThis.__SPRITE_IMG_WORKER__ = a.img;
+  if (!globalThis.__SPRITE_IMG__) {
+    globalThis.__SPRITE_IMG__ = a.img;
   }
 }
 
-export function nextFrame(anim, t) {
+export async function initMageAtlas() {
+  const a = await __loadAtlas('mage_sprites.json').catch(() => null);
+  if (!a) return;
+  Object.assign(FRAMES, a.meta.frames || {});
+  Object.assign(ANIMS, a.meta.animations || {});
+  globalThis.__SPRITE_IMG_MAGE__ = a.img;
+}
+
+export async function initTerrainAtlas() {
+  const a = await __loadAtlas('terrain_sprites.json').catch(() => null);
+  if (!a) return;
+  Object.assign(FRAMES, a.meta.frames || {});
+  Object.assign(ANIMS, a.meta.animations || {});
+  globalThis.__SPRITE_IMG_TERRAIN__ = a.img;
+}
+
+export function nextFrame(anim, t, fps = 10) {
   const seq = ANIMS[anim];
   if (!seq) return null;
-  const idx = Math.floor((t * 10) % seq.length);
+  const idx = Math.floor((t * fps) % seq.length);
   return seq[idx];
 }
 
@@ -456,7 +475,12 @@ export function drawSprite(ctx, name, x, y, opts = {}) {
       flipY = false,
       rotate = 0,
     } = opts;
-    const img = name.startsWith('worker_') ? globalThis.__SPRITE_IMG_WORKER__ : globalThis.__SPRITE_IMG__;
+    const img =
+      name.startsWith('worker_') ? globalThis.__SPRITE_IMG_WORKER__ :
+      name.startsWith('mage_')   ? globalThis.__SPRITE_IMG_MAGE__   :
+      (name.startsWith('tree_') || name.startsWith('grass_') || name.startsWith('water_') || name === 'dirt')
+        ? globalThis.__SPRITE_IMG_TERRAIN__
+        : globalThis.__SPRITE_IMG__;
     if (!img) return;
     ctx.save();
     ctx.imageSmoothingEnabled = false;

--- a/src/terrain.js
+++ b/src/terrain.js
@@ -43,6 +43,24 @@ function hash(x, y) {
   return h;
 }
 
+function drawTileSprite(ctx, tile, sx, sy, zoom) {
+  if (!globalThis.drawSprite || !globalThis.FRAMES) return false;
+  let name = null;
+
+  if (tile.kind === 'water') {
+    name = globalThis.nextFrame ? globalThis.nextFrame('water_loop', globalThis.simTime || 0, 8) : 'water_0';
+  } else if (tile.kind === 'grass') {
+    const h = (tile.x * 73856093 ^ tile.y * 19349663) & 3;
+    name = h === 0 ? 'grass_flowers' : (h & 1 ? 'grass_A' : 'grass_B');
+  } else if (tile.kind === 'dirt') {
+    name = 'dirt';
+  }
+
+  if (!name || !globalThis.FRAMES[name]) return false;
+  globalThis.drawSprite(name, sx, sy, zoom);
+  return true;
+}
+
 export function genBlockers() {
   const { rand, clamp, world } = globalThis;
   blockers.length = 0;
@@ -67,22 +85,26 @@ export function drawTerrain() {
   for (let y = startY; y <= endY; y += step) {
     for (let x = startX; x <= endX; x += step) {
       const s = worldToScreen(x, y);
-      const dx = toPixel ? toPixel(s.x) : s.x;
-      const dy = toPixel ? toPixel(s.y) : s.y;
-      const size = step * world.zoom;
-      ctx.drawImage(grassTile, dx, dy, size, size);
       const tx = Math.floor(x / step), ty = Math.floor(y / step);
-      if ((hash(tx, ty) & 255) < 10) {
-        ctx.drawImage(waterTile, dx, dy, size, size);
-        const t = (globalThis.simTime || 0) * WATER.waveSpeed;
-        ctx.save();
-        ctx.globalAlpha = 0.2;
-        ctx.fillStyle = '#fff';
-        for (let i = 0; i < size; i += 8) {
-          const ry = Math.sin((i / size + t) * Math.PI * 2) * WATER.waveAmp;
-          ctx.fillRect(dx + i, dy + size / 2 + ry, 8, WATER.rippleScale * size);
+      const kind = ((hash(tx, ty) & 255) < 10) ? 'water' : 'grass';
+      if (!drawTileSprite(ctx, { kind, x: tx, y: ty }, s.x, s.y, world.zoom)) {
+        const dx = toPixel ? toPixel(s.x) : s.x;
+        const dy = toPixel ? toPixel(s.y) : s.y;
+        const size = step * world.zoom;
+        if (kind === 'water') {
+          ctx.drawImage(waterTile, dx, dy, size, size);
+          const t = (globalThis.simTime || 0) * WATER.waveSpeed;
+          ctx.save();
+          ctx.globalAlpha = 0.2;
+          ctx.fillStyle = '#fff';
+          for (let i = 0; i < size; i += 8) {
+            const ry = Math.sin((i / size + t) * Math.PI * 2) * WATER.waveAmp;
+            ctx.fillRect(dx + i, dy + size / 2 + ry, 8, WATER.rippleScale * size);
+          }
+          ctx.restore();
+        } else {
+          ctx.drawImage(grassTile, dx, dy, size, size);
         }
-        ctx.restore();
       }
     }
   }
@@ -96,8 +118,13 @@ export function drawBlockers() {
     const dx = toPixel ? toPixel(topLeft.x) : topLeft.x;
     const dy = toPixel ? toPixel(topLeft.y) : topLeft.y;
     if (b.kind === 'tree') {
-      drawShadow(topLeft.x + size / 2, topLeft.y + size * 0.75, size * 0.5);
-      ctx.drawImage(treeBase, dx, dy, size, size);
+      const center = worldToScreen(b.x, b.y);
+      drawShadow(center.x, center.y + size * 0.25, size * 0.5);
+      if (!globalThis.drawSprite || !globalThis.FRAMES || !globalThis.FRAMES['tree_oak']) {
+        ctx.drawImage(treeBase, dx, dy, size, size);
+      } else {
+        globalThis.drawSprite('tree_oak', center.x, center.y, world.zoom);
+      }
     } else {
       const frame = Math.floor((globalThis.simTime || 0) * WATER.animSpeed) % waterBase.length;
       ctx.drawImage(waterBase[frame], dx, dy, size, size);


### PR DESCRIPTION
## Summary
- load mage and terrain sprite atlases alongside existing worker atlas
- render hero, terrain tiles, and trees using new atlas frames
- initialize new atlases during startup

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f0ac4cbe483278172fcfa84a10e08