### PR TITLE
Load mage and terrain sprite atlases

### DIFF
--- a/docs/mage_sprites.json
+++ b/docs/mage_sprites.json
@@ -1,0 +1,17 @@
+{
+  "imageData": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAN0lEQVR4nO3OsQ0AIAhFQXT/nXECYwEJhXc14b8I4HfrfZLZMHPd2fXnNQIECBAgQICA8QBg3AEAFwIiEweGWQAAAABJRU5ErkJggg==",
+  "frames": {
+    "mage_idle_0":   { "frame": { "x": 0, "y": 0, "w": 32, "h": 32 }, "anchor": { "x": 16, "y": 24 } },
+    "mage_walk_0":   { "frame": { "x": 0, "y": 0, "w": 32, "h": 32 }, "anchor": { "x": 16, "y": 24 } },
+    "mage_cast_0":   { "frame": { "x": 0, "y": 0, "w": 32, "h": 32 }, "anchor": { "x": 16, "y": 24 } },
+    "mage_attack_0": { "frame": { "x": 0, "y": 0, "w": 32, "h": 32 }, "anchor": { "x": 16, "y": 24 } },
+    "mage_death_0":  { "frame": { "x": 0, "y": 0, "w": 32, "h": 32 }, "anchor": { "x": 16, "y": 24 } }
+  },
+  "animations": {
+    "mage_idle":   ["mage_idle_0"],
+    "mage_walk":   ["mage_walk_0"],
+    "mage_cast":   ["mage_cast_0"],
+    "mage_attack": ["mage_attack_0"],
+    "mage_death":  ["mage_death_0"]
+  }
+}

--- a/docs/terrain_sprites.json
+++ b/docs/terrain_sprites.json
@@ -1,0 +1,15 @@
+{
+  "imageData": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAIAAAABACAYAAADS1n9/AAABpElEQVR4nO3cPVLDMBRFYdnDDrIYCuqwo/Tus6TUFCwmazAFMgT8l/FYfpo552sokljM6OpJUSw3qU99ivQZ2npKr7HNX99Poe23oa0r3Ev0P1CLxzLYBLwexQoAZwDgnAKytbJc+vUoVgA4AwBnAOAMAJyLwMx9ACEZADingMx9ACEZADgDAGcA4FwEZu4DCMkAwDkFZO4DCMkAwBkAOAMA5yIwcx9ASAYAzikgcx9ASAYAbrUyXc+n0fMDLm/3+fd/jM+7X273hXb62OcTdKGtp9Q1obPD02uApU6fe99UGFSX1QA82/GLn71tvoQKW14DdDs9Pmav62h30xWgRIcN1+yq/UaENK4ApUer1aAqfg2E+xuAo0anVaAavwE4ulMMQRWcAuC+AxA1Gq0C4awAcAYArrUMs1kB4AwAnAGAMwBwBgDOAMC1/j7PZgWAMwBww49BMdOA0084KwDc4w0hx45GR38V/t8Sdkyn2PnVcAqAm7otvOzodPRXZe5gSJP/7nevgB1fpbWjYft0mp1frdXDocMJ3y2HRH8+m7YfMFVZXxGfSOLoNXkjAAAAAElFTkSuQmCC",
+  "frames": {
+    "grass_A":      { "frame": { "x": 0,  "y": 0,  "w": 32, "h": 32 }, "anchor": { "x": 16, "y": 16 } },
+    "grass_B":      { "frame": { "x": 32, "y": 0,  "w": 32, "h": 32 }, "anchor": { "x": 16, "y": 16 } },
+    "grass_flowers":{ "frame": { "x": 64, "y": 0,  "w": 32, "h": 32 }, "anchor": { "x": 16, "y": 16 } },
+    "dirt":         { "frame": { "x": 96, "y": 0,  "w": 32, "h": 32 }, "anchor": { "x": 16, "y": 16 } },
+    "tree_oak":     { "frame": { "x": 0,  "y": 32, "w": 32, "h": 32 }, "anchor": { "x": 16, "y": 32 } },
+    "water_0":      { "frame": { "x": 32, "y": 32, "w": 32, "h": 32 }, "anchor": { "x": 16, "y": 16 } },
+    "water_1":      { "frame": { "x": 64, "y": 32, "w": 32, "h": 32 }, "anchor": { "x": 16, "y": 16 } }
+  },
+  "animations": {
+    "water_loop": ["water_0", "water_1"]
+  }
+}

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,4 @@
-import { drawSprite, nextFrame, initSprites, initWorkerAtlas, initMageAtlas, initTerrainAtlas } from "./sprites.js";
+import { drawSprite, nextFrame, initSprites } from "./sprites.js";
 import { Unit, Structure, ResourceNode, ItemDrop, NeutralCreep, Projectile, getById, enemiesFor, allUnits, allStructures, nearestNode, lootFromTier } from "./entities.js";
 import state from './state.js';
 import { AIController } from './ai.js';
@@ -16,9 +16,6 @@ const mini = document.getElementById('minimap'), mctx = mini.getContext('2d'); m
 globalThis.drawSprite = (name, x, y, scale = 1, override = {}) => drawSprite(ctx, name, x, y, { scale, override });
 globalThis.nextFrame = nextFrame;
 await initSprites();
-await initWorkerAtlas();
-await initMageAtlas();
-await initTerrainAtlas();
 const DPR = Math.max(1, window.devicePixelRatio || 1);
 mini.width = Math.floor(mini.clientWidth * DPR);
 mini.height = Math.floor(mini.clientHeight * DPR);

--- a/src/sprites.js
+++ b/src/sprites.js
@@ -373,7 +373,11 @@ async function __loadAtlas(name) {
 }
 
 export async function initSprites() {
-  // baseline sprites already available; nothing to do here for now
+  await Promise.all([
+    initWorkerAtlas(),
+    initMageAtlas(),
+    initTerrainAtlas()
+  ]);
 }
 
 export async function initWorkerAtlas() {


### PR DESCRIPTION
## Summary
- initialize worker, mage, and terrain sprite atlases together
- streamline main setup to load sprite atlases via a single call

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f0da9b3fc8327a9c5b742e4bb33b4