### PR TITLE
fix: guard sprite selection for missing frames

### DIFF
--- a/src/sprites.js
+++ b/src/sprites.js
@@ -421,6 +421,10 @@ export function nextFrame(anim, t, fps = 10) {
 
 // выбрать правильный атлас по имени кадра
 export function pickSpriteImage(name) {
+  // Guard against undefined sprite names which can occur when an animation
+  // frame lookup fails. In that case fall back to the default sprite atlas so
+  // that callers can safely skip rendering without throwing.
+  if (typeof name !== 'string') return globalThis.__SPRITE_IMG__;
   if (name.startsWith('worker_')) return globalThis.__SPRITE_IMG_WORKER__;
   if (name.startsWith('mage_')) return globalThis.__SPRITE_IMG_MAGE__;
   if (
@@ -448,9 +452,15 @@ export function drawTile(
   zoom,
   ctx = globalThis.ctx
 ) {
+  // Skip drawing if no sprite name was provided. This can happen when an
+  // animation lookup fails and returns `null`.
+  if (typeof name !== 'string') return;
+
   const F = globalThis.FRAMES?.[name];
+  if (!F) return;
+
   const IMG = pickSpriteImage(name);
-  if (!F || !IMG) return;
+  if (!IMG) return;
 
   // мировые координаты верхнего-левого угла клетки:
   const wx = tileX * ts;

--- a/src/terrain.js
+++ b/src/terrain.js
@@ -111,7 +111,14 @@ export function drawTerrain() {
       const kind = ((hash(i, j) & 255) < 10) ? 'water' : 'grass';
       let name = null;
       if (kind === 'water') {
-        name = globalThis.nextFrame ? globalThis.nextFrame('water_loop', globalThis.simTime || 0, 8) : 'water_0';
+        // When the water animation atlas hasn't loaded yet, nextFrame may
+        // return null which previously resulted in an undefined sprite name
+        // being passed to drawTile. Fallback to the first frame to avoid
+        // runtime errors and ensure water tiles still render.
+        const frame = globalThis.nextFrame
+          ? globalThis.nextFrame('water_loop', globalThis.simTime || 0, 8)
+          : null;
+        name = frame || 'water_0';
       } else if (kind === 'grass') {
         const h = ((i * 73856093) ^ (j * 19349663)) & 3;
         name = h === 0 ? 'grass_flowers' : (h & 1 ? 'grass_A' : 'grass_B');


### PR DESCRIPTION
## Summary
- avoid calling `startsWith` on missing sprite names
- fall back to first water frame when animation data is absent

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f1f2a544c83278c27dda11af7a1a6