### PR TITLE
feat: add paladin sprite atlas

### DIFF
--- a/src/entities.js
+++ b/src/entities.js
@@ -261,13 +261,31 @@ export class Unit extends Entity {
     const ctx = globalThis.ctx;
     const col = globalThis.players[this.owner]?.color || '#9fb2a1';
     globalThis.drawShadow(s.x, s.y + 12 * zoom, 12 * zoom);
-    if (this.isHero && globalThis.nextFrame && globalThis.drawSprite) {
+    if (this.isHero && globalThis.nextFrame && globalThis.drawSprite && globalThis.FRAMES) {
+      if (this.heroClass === 'paladin') {
+        let anim = 'paladin_idle';
+        if (this.dead) anim = 'paladin_death';
+        else if (this.state === 'cast') anim = 'paladin_cast';
+        else if (this.state === 'fight') anim = 'paladin_attack';
+        else if (this.state === 'move') anim = 'paladin_walk';
+        const frame = globalThis.nextFrame(
+          anim,
+          globalThis.simTime || 0,
+          anim === 'paladin_cast' ? 12 : 10
+        ) || 'paladin_idle_0';
+        globalThis.drawSprite(frame, s.x, s.y, zoom);
+        return;
+      }
       let anim = 'mage_idle';
       if (this.dead) anim = 'mage_death';
       else if (this.state === 'cast') anim = 'mage_cast';
       else if (this.state === 'fight') anim = 'mage_attack';
       else if (this.state === 'move') anim = 'mage_walk';
-      const frame = globalThis.nextFrame(anim, globalThis.simTime || 0, anim === 'mage_cast' ? 12 : 10) || 'mage_idle_0';
+      const frame = globalThis.nextFrame(
+        anim,
+        globalThis.simTime || 0,
+        anim === 'mage_cast' ? 12 : 10
+      ) || 'mage_idle_0';
       globalThis.drawSprite(frame, s.x, s.y, zoom);
       return;
     }

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,4 @@
-import { drawSprite, nextFrame, initSprites, initWorkerAtlas, initMageAtlas, initTerrainAtlas } from "./sprites.js";
+import { drawSprite, nextFrame, initSprites, initWorkerAtlas, initMageAtlas, initTerrainAtlas, initPaladinAtlas } from "./sprites.js";
 import { Unit, Structure, ResourceNode, ItemDrop, NeutralCreep, Projectile, getById, enemiesFor, allUnits, allStructures, nearestNode, lootFromTier } from "./entities.js";
 import state from './state.js';
 import { AIController } from './ai.js';
@@ -19,6 +19,7 @@ await initSprites();
 await initWorkerAtlas();
 await initMageAtlas();
 await initTerrainAtlas();
+await initPaladinAtlas();
 const DPR = Math.max(1, window.devicePixelRatio || 1);
 mini.width = Math.floor(mini.clientWidth * DPR);
 mini.height = Math.floor(mini.clientHeight * DPR);

--- a/src/sprites.js
+++ b/src/sprites.js
@@ -412,6 +412,14 @@ export async function initTerrainAtlas() {
   globalThis.__SPRITE_IMG_TERRAIN__ = a.img;
 }
 
+export async function initPaladinAtlas() {
+  const a = await __loadAtlas('paladin_sprites.json').catch(() => null);
+  if (!a) return;
+  Object.assign(FRAMES, a.meta.frames || {});
+  Object.assign(ANIMS, a.meta.animations || {});
+  globalThis.__SPRITE_IMG_PALADIN__ = a.img;
+}
+
 export function nextFrame(anim, t, fps = 10) {
   const seq = ANIMS[anim];
   if (!seq) return null;
@@ -425,8 +433,9 @@ export function pickSpriteImage(name) {
   // frame lookup fails. In that case fall back to the default sprite atlas so
   // that callers can safely skip rendering without throwing.
   if (typeof name !== 'string') return globalThis.__SPRITE_IMG__;
-  if (name.startsWith('worker_')) return globalThis.__SPRITE_IMG_WORKER__;
+  if (name.startsWith('paladin_')) return globalThis.__SPRITE_IMG_PALADIN__;
   if (name.startsWith('mage_')) return globalThis.__SPRITE_IMG_MAGE__;
+  if (name.startsWith('worker_')) return globalThis.__SPRITE_IMG_WORKER__;
   if (
     name.startsWith('grass_') ||
     name.startsWith('water_') ||
@@ -552,9 +561,10 @@ export function drawSprite(ctx, name, x, y, opts = {}) {
       rotate = 0,
     } = opts;
     const img =
-      name.startsWith('worker_') ? globalThis.__SPRITE_IMG_WORKER__ :
-      name.startsWith('mage_')   ? globalThis.__SPRITE_IMG_MAGE__   :
-      (name.startsWith('tree_') || name.startsWith('grass_') || name.startsWith('water_') || name === 'dirt')
+      name.startsWith('paladin_') ? globalThis.__SPRITE_IMG_PALADIN__ :
+      name.startsWith('mage_')    ? globalThis.__SPRITE_IMG_MAGE__    :
+      name.startsWith('worker_')  ? globalThis.__SPRITE_IMG_WORKER__  :
+      (name.startsWith('grass_') || name.startsWith('water_') || name === 'dirt' || name.startsWith('tree_'))
         ? globalThis.__SPRITE_IMG_TERRAIN__
         : globalThis.__SPRITE_IMG__;
     if (!img) return;


### PR DESCRIPTION
## Summary
- add paladin sprite atlas initialization and image routing
- load paladin atlas in main module
- render paladin hero using sprite animations

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f24b2b9fc83279063519ac0dd8f35