### PR TITLE
Add rogue hero sprites and animations

### DIFF
--- a/src/entities.js
+++ b/src/entities.js
@@ -275,6 +275,19 @@ export class Unit extends Entity {
         ) || 'paladin_idle_0';
         globalThis.drawSprite(frame, s.x, s.y, zoom);
         return;
+      } else if (this.heroClass === 'rogue') {
+        let anim = 'rogue_idle';
+        if (this.dead) anim = 'rogue_death';
+        else if (this.state === 'cast') anim = 'rogue_cast';
+        else if (this.state === 'fight') anim = 'rogue_attack';
+        else if (this.state === 'move') anim = 'rogue_walk';
+        const frame = globalThis.nextFrame(
+          anim,
+          globalThis.simTime || 0,
+          anim === 'rogue_cast' ? 12 : 10
+        ) || 'rogue_idle_0';
+        globalThis.drawSprite(frame, s.x, s.y, zoom);
+        return;
       }
       let anim = 'mage_idle';
       if (this.dead) anim = 'mage_death';

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,4 @@
-import { drawSprite, nextFrame, initSprites, initWorkerAtlas, initMageAtlas, initTerrainAtlas, initPaladinAtlas } from "./sprites.js";
+import { drawSprite, nextFrame, initSprites, initWorkerAtlas, initMageAtlas, initTerrainAtlas, initPaladinAtlas, initRogueAtlas } from "./sprites.js";
 import { Unit, Structure, ResourceNode, ItemDrop, NeutralCreep, Projectile, getById, enemiesFor, allUnits, allStructures, nearestNode, lootFromTier } from "./entities.js";
 import state from './state.js';
 import { AIController } from './ai.js';
@@ -20,6 +20,7 @@ await initWorkerAtlas();
 await initMageAtlas();
 await initTerrainAtlas();
 await initPaladinAtlas();
+await initRogueAtlas();
 const DPR = Math.max(1, window.devicePixelRatio || 1);
 mini.width = Math.floor(mini.clientWidth * DPR);
 mini.height = Math.floor(mini.clientHeight * DPR);

--- a/src/sprites.js
+++ b/src/sprites.js
@@ -427,6 +427,14 @@ export async function initPaladinAtlas() {
   globalThis.__SPRITE_IMG_PALADIN__ = a.img;
 }
 
+export async function initRogueAtlas() {
+  const a = await __loadAtlas('rogue_sprites.json').catch(() => null);
+  if (!a) return;
+  Object.assign(FRAMES, a.meta.frames || {});
+  Object.assign(ANIMS, a.meta.animations || {});
+  globalThis.__SPRITE_IMG_ROGUE__ = a.img;
+}
+
 export function nextFrame(anim, t, fps = 10) {
   const seq = ANIMS[anim];
   if (!seq) return null;
@@ -441,6 +449,7 @@ export function pickSpriteImage(name) {
   // that callers can safely skip rendering without throwing.
   if (typeof name !== 'string') return globalThis.__SPRITE_IMG__;
   if (name.startsWith('paladin_')) return globalThis.__SPRITE_IMG_PALADIN__;
+  if (name.startsWith('rogue_')) return globalThis.__SPRITE_IMG_ROGUE__;
   if (name.startsWith('mage_')) return globalThis.__SPRITE_IMG_MAGE__;
   if (name.startsWith('worker_')) return globalThis.__SPRITE_IMG_WORKER__;
   if (
@@ -569,6 +578,7 @@ export function drawSprite(ctx, name, x, y, opts = {}) {
     } = opts;
     const img =
       name.startsWith('paladin_') ? globalThis.__SPRITE_IMG_PALADIN__ :
+      name.startsWith('rogue_')   ? globalThis.__SPRITE_IMG_ROGUE__   :
       name.startsWith('mage_')    ? globalThis.__SPRITE_IMG_MAGE__    :
       name.startsWith('worker_')  ? globalThis.__SPRITE_IMG_WORKER__  :
       (name.startsWith('grass_') || name.startsWith('water_') || name === 'dirt' || name.startsWith('tree_'))


### PR DESCRIPTION
## Summary
- load rogue sprite atlas and route rendering through rogue-specific images
- initialize rogue sprites in game setup
- render rogue hero using dedicated animation set

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f4aba00f4832787a6a9b328516d2b