### PR TITLE
Fix missing atlas imports for unit sprites

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,21 @@
-import { drawSprite, nextFrame, initSprites, initWorkerAtlas, initMageAtlas, initTerrainAtlas, initPaladinAtlas, initRogueAtlas } from "./sprites.js";
+import {
+  drawSprite,
+  nextFrame,
+  initSprites,
+  initWorkerAtlas,
+  initMageAtlas,
+  initTerrainAtlas,
+  initPaladinAtlas,
+  initRogueAtlas,
+  initSoldierAtlas,
+  initArcherAtlas,
+  initDemonAtlas,
+  initElementalAtlas,
+  initForestTrollAtlas,
+  initGnomeSeekerAtlas,
+  initHermitMageAtlas,
+  initWildBeastAtlas
+} from "./sprites.js";
 import { Unit, Structure, ResourceNode, ItemDrop, NeutralCreep, Projectile, getById, enemiesFor, allUnits, allStructures, nearestNode, lootFromTier } from "./entities.js";
 import state from './state.js';
 import { AIController } from './ai.js';


### PR DESCRIPTION
## Summary
- import all unit sprite atlas initializers in `main.js`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f55a162f883278093cf01d0a9ece1