### PR TITLE
Fix sprite atlas routing and archmage hero separation

### DIFF
--- a/src/entities.js
+++ b/src/entities.js
@@ -272,9 +272,8 @@ export class Unit extends Entity {
           anim,
           globalThis.simTime || 0,
           anim === 'paladin_cast' ? 12 : 10
-        ) || 'paladin_idle_0';
-        globalThis.drawSprite(frame, s.x, s.y, zoom);
-        return;
+        ) || (globalThis.ANIMS[anim] && globalThis.ANIMS[anim][0]);
+        if (frame) { globalThis.drawSprite(frame, s.x, s.y, zoom); return; }
       } else if (this.heroClass === 'rogue') {
         let anim = 'rogue_idle';
         if (this.dead) anim = 'rogue_death';
@@ -285,22 +284,20 @@ export class Unit extends Entity {
           anim,
           globalThis.simTime || 0,
           anim === 'rogue_cast' ? 12 : 10
-        ) || 'rogue_idle_0';
-        globalThis.drawSprite(frame, s.x, s.y, zoom);
-        return;
+        ) || (globalThis.ANIMS[anim] && globalThis.ANIMS[anim][0]);
+        if (frame) { globalThis.drawSprite(frame, s.x, s.y, zoom); return; }
       }
-      let anim = 'mage_idle';
-      if (this.dead) anim = 'mage_death';
-      else if (this.state === 'cast') anim = 'mage_cast';
-      else if (this.state === 'fight') anim = 'mage_attack';
-      else if (this.state === 'move') anim = 'mage_walk';
+      let anim = 'archmage_idle';
+      if (this.dead) anim = 'archmage_death';
+      else if (this.state === 'cast') anim = 'archmage_cast';
+      else if (this.state === 'fight') anim = 'archmage_attack';
+      else if (this.state === 'move') anim = 'archmage_walk';
       const frame = globalThis.nextFrame(
         anim,
         globalThis.simTime || 0,
-        anim === 'mage_cast' ? 12 : 10
-      ) || 'mage_idle_0';
-      globalThis.drawSprite(frame, s.x, s.y, zoom);
-      return;
+        anim === 'archmage_cast' ? 12 : 10
+      ) || (globalThis.ANIMS[anim] && globalThis.ANIMS[anim][0]);
+      if (frame) { globalThis.drawSprite(frame, s.x, s.y, zoom); return; }
     }
     if (this.type === 'worker' && !this.isHero && globalThis.nextFrame) {
       const movingStates = ['move', 'to_node', 'to_hq', 'build'];
@@ -308,8 +305,9 @@ export class Unit extends Entity {
       if (this.state === 'harvest') animName = 'worker_gather';
       else if (movingStates.includes(this.state)) animName = 'worker_walk';
       else if (this.state === 'fight') animName = 'worker_attack';
-      const frame = globalThis.nextFrame(animName, globalThis.simTime || 0) || 'worker_idle_0';
-      globalThis.drawSprite(frame, s.x, s.y, zoom);
+      const frame = globalThis.nextFrame(animName, globalThis.simTime || 0) ||
+        (globalThis.ANIMS[animName] && globalThis.ANIMS[animName][0]) || null;
+      if (frame) { globalThis.drawSprite(frame, s.x, s.y, zoom); return; }
     } else if (globalThis.nextFrame && globalThis.drawSprite && globalThis.FRAMES) {
       let prefix = null;
       if (['soldier', 'archer', 'mage', 'demon', 'elemental'].includes(this.type)) {
@@ -321,8 +319,9 @@ export class Unit extends Entity {
         else if (this.state === 'cast') anim = `${prefix}_cast`;
         else if (this.state === 'fight') anim = `${prefix}_attack`;
         else if (this.state === 'move') anim = `${prefix}_walk`;
-        const frame = globalThis.nextFrame(anim, globalThis.simTime || 0) || `${prefix}_idle_0`;
-        globalThis.drawSprite(frame, s.x, s.y, zoom);
+        const frame = globalThis.nextFrame(anim, globalThis.simTime || 0) ||
+          (globalThis.ANIMS[anim] && globalThis.ANIMS[anim][0]);
+        if (frame) { globalThis.drawSprite(frame, s.x, s.y, zoom); return; }
       } else {
         ctx.save();
         ctx.translate(s.x, s.y);
@@ -742,8 +741,9 @@ export class NeutralCreep extends Entity {
       if (this.dead) anim = `${prefix}_death`;
       else if (this.attackTimer > 0) anim = `${prefix}_attack`;
       else if (this.aggro) anim = `${prefix}_walk`;
-      const frame = globalThis.nextFrame(anim, globalThis.simTime || 0) || `${prefix}_idle_0`;
-      globalThis.drawSprite(frame, s.x, s.y, zoom);
+      const frame = globalThis.nextFrame(anim, globalThis.simTime || 0) ||
+        (globalThis.ANIMS[anim] && globalThis.ANIMS[anim][0]);
+      if (frame) { globalThis.drawSprite(frame, s.x, s.y, zoom); return; }
     } else {
       let band = '#9fb2a1';
       if (this.kind === 'mage') band = '#8ad';

--- a/src/main.js
+++ b/src/main.js
@@ -1,9 +1,9 @@
 import {
   drawSprite,
-  nextFrame,
   initSprites,
   initWorkerAtlas,
-  initMageAtlas,
+  initMageUnitAtlas,
+  initArchmageAtlas,
   initTerrainAtlas,
   initPaladinAtlas,
   initRogueAtlas,
@@ -31,21 +31,25 @@ state.rand = rand;
 const cvs = document.getElementById('game'), ctx = cvs.getContext('2d'); ctx.imageSmoothingEnabled = false;
 const mini = document.getElementById('minimap'), mctx = mini.getContext('2d'); mctx.imageSmoothingEnabled = false;
 globalThis.drawSprite = (name, x, y, scale = 1, override = {}) => drawSprite(ctx, name, x, y, { scale, override });
-globalThis.nextFrame = nextFrame;
+globalThis.SPRITES_READY = false;
 await initSprites();
-await initWorkerAtlas();
-await initMageAtlas();
-await initTerrainAtlas();
-await initPaladinAtlas();
-await initRogueAtlas();
-await initSoldierAtlas();
-await initArcherAtlas();
-await initDemonAtlas();
-await initElementalAtlas();
-await initForestTrollAtlas();
-await initGnomeSeekerAtlas();
-await initHermitMageAtlas();
-await initWildBeastAtlas();
+await Promise.all([
+  initTerrainAtlas(),
+  initWorkerAtlas(),
+  initSoldierAtlas(),
+  initArcherAtlas(),
+  initMageUnitAtlas(),
+  initElementalAtlas(),
+  initDemonAtlas(),
+  initHermitMageAtlas(),
+  initGnomeSeekerAtlas(),
+  initForestTrollAtlas(),
+  initWildBeastAtlas(),
+  initPaladinAtlas(),
+  initRogueAtlas(),
+  initArchmageAtlas()
+]);
+globalThis.SPRITES_READY = true;
 const DPR = Math.max(1, window.devicePixelRatio || 1);
 mini.width = Math.floor(mini.clientWidth * DPR);
 mini.height = Math.floor(mini.clientHeight * DPR);
@@ -646,6 +650,7 @@ globalThis.resetGame = resetGame;
       function drawHp(x, y, k) { k = clamp(k, 0, 1); ctx.fillStyle = 'rgba(0,0,0,.55)'; ctx.fillRect(x - 18, y - 4, 36, 6); ctx.fillStyle = k > .5 ? '#6be36b' : (k > .25 ? '#ffd36b' : '#ff6b6b'); ctx.fillRect(x - 18, y - 4, 36 * k, 6); ctx.strokeStyle = 'rgba(255,255,255,.15)'; ctx.strokeRect(x - 18, y - 4, 36, 6); }
 globalThis.drawHp = drawHp;
       function loop(t) {
+        if (!globalThis.SPRITES_READY) { requestAnimationFrame(loop); return; }
         const dt = Math.min(0.033, (t - last) / 1000); last = t; simTime += dt; globalThis.simTime = simTime;
         clearVisible(); for (const s of players[0].structures) revealCircle(s.x, s.y, 520); for (const u of players[0].units) revealCircle(u.x, u.y, 480);
         if (!state.paused) {

--- a/src/sprites.js
+++ b/src/sprites.js
@@ -403,12 +403,25 @@ export async function initWorkerAtlas() {
   }
 }
 
-export async function initMageAtlas() {
+export async function initMageUnitAtlas() {
   const a = await __loadAtlas('mage_sprites.json').catch(() => null);
   if (!a) return;
   Object.assign(FRAMES, a.meta.frames || {});
   Object.assign(ANIMS, a.meta.animations || {});
-  globalThis.__SPRITE_IMG_MAGE__ = a.img;
+  globalThis.__SPRITE_IMG_MAGEUNIT__ = a.img;
+}
+
+export async function initArchmageAtlas() {
+  // Try dedicated archmage atlas; fall back to mage atlas if missing
+  let a = await __loadAtlas('archmage_sprites.json').catch(() => null);
+  if (!a) {
+    a = await __loadAtlas('mage_sprites.json').catch(() => null);
+    if (!a) return;
+  }
+  Object.assign(FRAMES, a.meta.frames || {});
+  Object.assign(ANIMS, a.meta.animations || {});
+  globalThis.__SPRITE_IMG_ARCHMAGE__ = a.img;
+  aliasAnimPrefix('mage_', 'archmage_');
 }
 
 export async function initTerrainAtlas() {
@@ -472,7 +485,7 @@ export async function initForestTrollAtlas() {
   if (!a) return;
   Object.assign(FRAMES, a.meta.frames || {});
   Object.assign(ANIMS, a.meta.animations || {});
-  globalThis.__SPRITE_IMG_FOREST_TROLL__ = a.img;
+  globalThis.__SPRITE_IMG_TROLL__ = a.img;
 }
 
 export async function initGnomeSeekerAtlas() {
@@ -480,7 +493,7 @@ export async function initGnomeSeekerAtlas() {
   if (!a) return;
   Object.assign(FRAMES, a.meta.frames || {});
   Object.assign(ANIMS, a.meta.animations || {});
-  globalThis.__SPRITE_IMG_GNOME_SEEKER__ = a.img;
+  globalThis.__SPRITE_IMG_GNOME__ = a.img;
 }
 
 export async function initHermitMageAtlas() {
@@ -488,7 +501,7 @@ export async function initHermitMageAtlas() {
   if (!a) return;
   Object.assign(FRAMES, a.meta.frames || {});
   Object.assign(ANIMS, a.meta.animations || {});
-  globalThis.__SPRITE_IMG_HERMIT_MAGE__ = a.img;
+  globalThis.__SPRITE_IMG_HERMIT__ = a.img;
 }
 
 export async function initWildBeastAtlas() {
@@ -496,49 +509,46 @@ export async function initWildBeastAtlas() {
   if (!a) return;
   Object.assign(FRAMES, a.meta.frames || {});
   Object.assign(ANIMS, a.meta.animations || {});
-  globalThis.__SPRITE_IMG_WILD_BEAST__ = a.img;
+  globalThis.__SPRITE_IMG_BEAST__ = a.img;
 }
 
 export function nextFrame(anim, t, fps = 10) {
-  const seq = ANIMS[anim];
-  if (!seq) return null;
-  const idx = Math.floor((t * fps) % seq.length);
-  return seq[idx];
+  const arr = ANIMS?.[anim];
+  if (!arr || !arr.length) return null;
+  const idx = Math.floor(t * fps) % arr.length;
+  return arr[idx];
 }
+globalThis.nextFrame = nextFrame;
 
 // выбрать правильный атлас по имени кадра
-export function pickSpriteImage(name) {
-  // Guard against undefined sprite names which can occur when an animation
-  // frame lookup fails. In that case fall back to the default sprite atlas so
-  // that callers can safely skip rendering without throwing.
+function routeImageByName(name) {
   if (typeof name !== 'string') return globalThis.__SPRITE_IMG__;
-  if (name.startsWith('paladin_')) return globalThis.__SPRITE_IMG_PALADIN__;
-  if (name.startsWith('rogue_')) return globalThis.__SPRITE_IMG_ROGUE__;
-  if (name.startsWith('soldier_')) return globalThis.__SPRITE_IMG_SOLDIER__;
-  if (name.startsWith('archer_')) return globalThis.__SPRITE_IMG_ARCHER__;
-  if (name.startsWith('demon_')) return globalThis.__SPRITE_IMG_DEMON__;
-  if (name.startsWith('elemental_')) return globalThis.__SPRITE_IMG_ELEMENTAL__;
-  if (name.startsWith('forest_troll_')) return globalThis.__SPRITE_IMG_FOREST_TROLL__;
-  if (name.startsWith('gnome_seeker_')) return globalThis.__SPRITE_IMG_GNOME_SEEKER__;
-  if (name.startsWith('hermit_mage_')) return globalThis.__SPRITE_IMG_HERMIT_MAGE__;
-  if (name.startsWith('wild_beast_')) return globalThis.__SPRITE_IMG_WILD_BEAST__;
-  if (name.startsWith('mage_')) return globalThis.__SPRITE_IMG_MAGE__;
-  if (name.startsWith('worker_')) return globalThis.__SPRITE_IMG_WORKER__;
-  if (name.startsWith('soldier_')) return globalThis.__SPRITE_IMG_SOLDIER__;
-  if (name.startsWith('archer_')) return globalThis.__SPRITE_IMG_ARCHER__;
-  if (name.startsWith('demon_')) return globalThis.__SPRITE_IMG_DEMON__;
-  if (name.startsWith('elemental_')) return globalThis.__SPRITE_IMG_ELEMENTAL__;
-  if (name.startsWith('forest_troll_')) return globalThis.__SPRITE_IMG_FOREST_TROLL__;
-  if (name.startsWith('gnome_seeker_')) return globalThis.__SPRITE_IMG_GNOME_SEEKER__;
-  if (name.startsWith('hermit_mage_')) return globalThis.__SPRITE_IMG_HERMIT_MAGE__;
-  if (name.startsWith('wild_beast_')) return globalThis.__SPRITE_IMG_WILD_BEAST__;
-  if (
-    name.startsWith('grass_') ||
-    name.startsWith('water_') ||
-    name === 'dirt' ||
-    name.startsWith('tree_')
-  )
+  // Heroes
+  if (name.startsWith('paladin_'))  return globalThis.__SPRITE_IMG_PALADIN__;
+  if (name.startsWith('rogue_'))    return globalThis.__SPRITE_IMG_ROGUE__;
+  if (name.startsWith('archmage_')) return globalThis.__SPRITE_IMG_ARCHMAGE__;
+
+  // Units
+  if (name.startsWith('soldier_'))      return globalThis.__SPRITE_IMG_SOLDIER__;
+  if (name.startsWith('archer_'))       return globalThis.__SPRITE_IMG_ARCHER__;
+  if (name.startsWith('mage_'))         return globalThis.__SPRITE_IMG_MAGEUNIT__;
+  if (name.startsWith('elemental_'))    return globalThis.__SPRITE_IMG_ELEMENTAL__;
+  if (name.startsWith('demon_'))        return globalThis.__SPRITE_IMG_DEMON__;
+  if (name.startsWith('hermit_mage_'))  return globalThis.__SPRITE_IMG_HERMIT__;
+  if (name.startsWith('gnome_seeker_')) return globalThis.__SPRITE_IMG_GNOME__;
+  if (name.startsWith('forest_troll_')) return globalThis.__SPRITE_IMG_TROLL__;
+  if (name.startsWith('wild_beast_'))   return globalThis.__SPRITE_IMG_BEAST__;
+  if (name.startsWith('worker_'))       return globalThis.__SPRITE_IMG_WORKER__;
+
+  // Terrain / buildings
+  if (name.startsWith('grass_') || name.startsWith('water_') || name === 'dirt' || name.startsWith('tree_'))
     return globalThis.__SPRITE_IMG_TERRAIN__;
+  if (
+    name.startsWith('hq_') || name.startsWith('well_') || name.startsWith('altar_') ||
+    name.startsWith('barracks_') || name.startsWith('range_') || name.startsWith('mBarracks_') ||
+    name.startsWith('square_') || /^(hq|well|altar|barracks|range|mBarracks|square)[AB]_/.test(name)
+  ) return globalThis.__SPRITE_IMG_BUILDINGS__;
+
   return globalThis.__SPRITE_IMG__;
 }
 
@@ -564,7 +574,7 @@ export function drawTile(
   const F = globalThis.FRAMES?.[name];
   if (!F) return;
 
-  const IMG = pickSpriteImage(name);
+  const IMG = routeImageByName(name);
   if (!IMG) return;
 
   // мировые координаты верхнего-левого угла клетки:
@@ -649,21 +659,8 @@ function buildSpriteImage(key, spr, w, h, scale, override) {
 export function drawSprite(ctx, name, x, y, opts = {}) {
   if (FRAMES[name]) {
     const f = FRAMES[name];
-    const {
-      scale = 1,
-      alpha = 1,
-      flipX = false,
-      flipY = false,
-      rotate = 0,
-    } = opts;
-    const img =
-      name.startsWith('paladin_') ? globalThis.__SPRITE_IMG_PALADIN__ :
-      name.startsWith('rogue_')   ? globalThis.__SPRITE_IMG_ROGUE__   :
-      name.startsWith('mage_')    ? globalThis.__SPRITE_IMG_MAGE__    :
-      name.startsWith('worker_')  ? globalThis.__SPRITE_IMG_WORKER__  :
-      (name.startsWith('grass_') || name.startsWith('water_') || name === 'dirt' || name.startsWith('tree_'))
-        ? globalThis.__SPRITE_IMG_TERRAIN__
-        : globalThis.__SPRITE_IMG__;
+    const { scale = 1, alpha = 1, flipX = false, flipY = false, rotate = 0 } = opts;
+    const img = routeImageByName(name);
     if (!img) return;
     ctx.save();
     ctx.imageSmoothingEnabled = false;
@@ -743,4 +740,13 @@ export function drawSprite(ctx, name, x, y, opts = {}) {
 export function drawSpriteLegacy(name, x, y, scale = 1, override = {}) {
   if (!globalThis.ctx) return;
   drawSprite(globalThis.ctx, name, x, y, { scale, override });
+}
+
+function aliasAnimPrefix(from, to) {
+  for (const [k, arr] of Object.entries(ANIMS)) {
+    if (k.startsWith(from)) ANIMS[k.replace(from, to)] = arr.map(n => n.replace(from, to));
+  }
+  for (const k of Object.keys(FRAMES)) {
+    if (k.startsWith(from)) FRAMES[k.replace(from, to)] = FRAMES[k];
+  }
 }


### PR DESCRIPTION
## Summary
- Route sprite atlases by name with hero priority and no worker fallbacks
- Load all atlases up-front and gate rendering until sprites are ready
- Distinguish archmage hero from mage unit using its own prefix

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f590c4a3883279eb5daf8c5838e26